### PR TITLE
OTC-242: Automatically update version in About in Mobile Apps

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,3 +1,6 @@
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
 apply plugin: 'com.android.application'
 apply from: "$project.rootDir/script-git-version.gradle"
 apply plugin: 'com.android.application'
@@ -7,6 +10,13 @@ def keystorePropertiesFile = file("keystore.properties");
 def keystoreProperties = new Properties()
 if ( keystorePropertiesFile.exists() ) {
     keystoreProperties.load(new FileInputStream(keystorePropertiesFile))
+}
+
+//generate date
+static def getDate() {
+    LocalDateTime date = LocalDateTime.now()
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern('dd MMMM yyyy HH:mm').withLocale(Locale.UK)
+    return date.format(formatter)
 }
 
 android {
@@ -53,6 +63,7 @@ android {
         buildConfigField "String", "RAR_PASSWORD", '")(#$1HsD"'
         buildConfigField "String", "APP_DIR", '"IMIS"'
         resValue "string", "app_name_policies", "Policies"
+        resValue "string", "ReleaseDateValue", getDate()
     }
     productFlavors {
         demoProd {

--- a/app/src/main/assets/pages/About.html
+++ b/app/src/main/assets/pages/About.html
@@ -50,10 +50,10 @@ In case of dispute arising out or in relation to the use of the program, it is s
 <div>
     <ul class="ulList infoOnly">
         <li id="liUploadRenewals">
-            <span class="lbl" id="Version" strName="Version"></span><span  class="info" id="beta">2.0.1</span>
+            <span class="lbl" id="Version" strName="Version"></span><span id="VersionValue" class="info" id="beta">2.0.1</span>
         </li>
         <li id="liUploadFeedback">
-            <span class="lbl" id="ReleaseDate" strName="ReleaseDate"></span><span  class="info">April 2020</span>
+            <span class="lbl" id="ReleaseDate" strName="ReleaseDate"></span><span id="ReleaseDateValue" strName="ReleaseDateValue" class="info"></span>
         </li>
     </ul>
 </div>


### PR DESCRIPTION
Changes:
- build.gradle now adds build datetime as a resource string ReleaseDateValue 
- About page now fetches data from ReleaseDateValue resource instead of fixed value

[https://openimis.atlassian.net/browse/OTC-242](
https://openimis.atlassian.net/browse/OTC-242)