### PR TITLE
OTC-75: Flexibility of loading of the Master Data off-line

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
         android:fullBackupContent="@xml/backup_descriptor"
         android:networkSecurityConfig="@xml/network_security_config"
         android:icon="@mipmap/ic_launcher"
-        android:label="@strings/app_name_policies"
+        android:label="@string/app_name_policies"
         android:roundIcon="@mipmap/ic_launcher"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"

--- a/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
+++ b/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
@@ -3816,7 +3816,7 @@ public class ClientAndroidInterface {
     //@TargetApi(Build.VERSION_CODES.KITKAT)
     public static void copy(String name, byte[] data) throws IOException {
         OutputStream out;
-        String photosDir = new Global().getSubdirectory("Photos");
+        String photosDir = Global.getGlobal().getSubdirectory("Photos");
 
         File file = new File(photosDir + File.separator + name);
         file.createNewFile();
@@ -4717,7 +4717,7 @@ public class ClientAndroidInterface {
                         @Override
                         public void run() {
                             ShowDialog(mContext.getResources().getString(R.string.DataDownloadedSuccess));
-                            Global global = new Global();
+                            Global global = Global.getGlobal();
                             global.setOfficerCode("");
 //                            Intent refresh = new Intent(mContext, MainActivity.class);
 //                            ((MainActivity)mContext).startActivity(refresh);

--- a/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
+++ b/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
@@ -3908,7 +3908,7 @@ public class ClientAndroidInterface {
     }
 
     public boolean unZipWithPassword(String fileName, String password) {
-        String targetPath = global.getSubdirectory("Database") + File.separator + fileName;
+        String targetPath = fileName;
         String unzippedFolderPath = global.getSubdirectory("Database");
         //String unzippedFolderPath = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS) + "/IMIS/Enrolment/Enrolment_"+global.getOfficerCode()+"_"+d+".xml";
         //here we not don't have password set yet so we pass password from Edit Text rar input

--- a/app/src/main/java/org/openimis/imispolicies/Global.java
+++ b/app/src/main/java/org/openimis/imispolicies/Global.java
@@ -30,9 +30,10 @@ import android.os.Environment;
 import android.util.Log;
 
 import java.io.File;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 
 import static org.openimis.imispolicies.BuildConfig.APP_DIR;
 
@@ -47,7 +48,10 @@ public class Global extends Application {
     private Token JWTToken;
 
     private String MainDirectory;
+    private String AppDirectory;
     private Map<String, String> SubDirectories = new HashMap<>();
+
+    private List<String> ProtectedDirectories = Arrays.asList("Authentications","Database");
 
     public Token getJWTToken() {
         return JWTToken;
@@ -129,15 +133,34 @@ public class Global extends Application {
         return MainDirectory;
     }
 
+    public String getAppDirectory() {
+        if (AppDirectory == null) {
+            AppDirectory = createOrCheckDirectory(getApplicationInfo().dataDir);
+
+            if ("".equals(AppDirectory)) {
+                Log.w("DIRS", "App directory could not be created");
+            }
+        }
+        return AppDirectory;
+    }
+
     public String getSubdirectory(String subdirectory) {
         if (!SubDirectories.containsKey(subdirectory)) {
-            String subDir = createOrCheckDirectory(getMainDirectory() + File.separator + subdirectory);
+            String directory;
 
-            if ("".equals(subDir)) {
+            if (ProtectedDirectories.contains(subdirectory)) {
+                directory = getAppDirectory();
+            } else {
+                directory = getMainDirectory();
+            }
+
+            String subDirPath = createOrCheckDirectory(directory + File.separator + subdirectory);
+
+            if ("".equals(subDirPath)) {
                 Log.w("DIRS", subdirectory + " directory could not be created");
                 return null;
             } else {
-                SubDirectories.put(subdirectory, subDir);
+                SubDirectories.put(subdirectory, subDirPath);
             }
         }
         return SubDirectories.get(subdirectory);

--- a/app/src/main/java/org/openimis/imispolicies/Global.java
+++ b/app/src/main/java/org/openimis/imispolicies/Global.java
@@ -26,6 +26,7 @@
 package org.openimis.imispolicies;
 
 import android.app.Application;
+import android.content.Context;
 import android.os.Environment;
 import android.util.Log;
 
@@ -38,6 +39,8 @@ import java.util.Map;
 import static org.openimis.imispolicies.BuildConfig.APP_DIR;
 
 public class Global extends Application {
+    private static Global GlobalContext;
+
     private String OfficerCode;
     private String OfficerName;
     private int UserId;
@@ -52,6 +55,20 @@ public class Global extends Application {
     private Map<String, String> SubDirectories = new HashMap<>();
 
     private List<String> ProtectedDirectories = Arrays.asList("Authentications","Database");
+
+    public static Global getGlobal() {
+        return GlobalContext;
+    }
+
+    public static Context getContext() {
+        return GlobalContext.getApplicationContext();
+    }
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        GlobalContext = this;
+    }
 
     public Token getJWTToken() {
         return JWTToken;

--- a/app/src/main/java/org/openimis/imispolicies/MainActivity.java
+++ b/app/src/main/java/org/openimis/imispolicies/MainActivity.java
@@ -38,7 +38,6 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
-import android.content.res.Resources;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -55,7 +54,6 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
-import android.view.MenuInflater;
 import android.view.View;
 import android.support.design.widget.NavigationView;
 import android.support.v4.view.GravityCompat;
@@ -72,7 +70,6 @@ import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
 
-import com.exact.CallSoap.CallSoap;
 import com.exact.general.General;
 
 import org.json.JSONArray;
@@ -89,7 +86,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStream;
 
 import static android.provider.Settings.ACTION_MANAGE_ALL_FILES_ACCESS_PERMISSION;
-import static java.security.AccessController.getContext;
 
 
 public class MainActivity extends AppCompatActivity
@@ -136,7 +132,7 @@ public class MainActivity extends AppCompatActivity
         super.onActivityResult(requestCode, resultCode, data);
         //when an image is selected
         if (requestCode == ClientAndroidInterface.RESULT_LOAD_IMG && resultCode == RESULT_OK && data != null) {
-            try{
+            try {
                 //get the image from data
                 Uri selectedImage = data.getData();
                 String[] filePathColumn = {MediaStore.Images.Media.DATA};
@@ -155,14 +151,14 @@ public class MainActivity extends AppCompatActivity
 
                 cursor.close();
                 ClientAndroidInterface.inProgress = false;
-            }catch (Exception e){
+            } catch (Exception e) {
                 e.printStackTrace();
             }
 
 
         }
         //mimi
-        else if(requestCode == ClientAndroidInterface.RESULT_SCAN && resultCode == RESULT_OK && data != null) {
+        else if (requestCode == ClientAndroidInterface.RESULT_SCAN && resultCode == RESULT_OK && data != null) {
             this.InsureeNumber = data.getStringExtra("SCAN_RESULT");
 
          /*   if (!Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
@@ -192,26 +188,36 @@ public class MainActivity extends AppCompatActivity
                 // ClientAndroidInterface.setInsuranceNo(InsuranceNo);
                 ClientAndroidInterface.inProgress = false;
             }*/
-        }else if(requestCode == 4 && resultCode == RESULT_OK){
+        } else if (requestCode == 4 && resultCode == RESULT_OK) {
             Uri uri = data.getData();
-            String path = "";
-            path = uri.getPath();
-            //File f = new File(path);
-            f = new File(path);
+            int size = 0;
 
+            String[] proj = {MediaStore.Files.FileColumns.SIZE};
+            Cursor c = getContentResolver().query(uri, proj, null, null, null);
+            c.moveToFirst();
+            size = c.getInt(0);
+
+            byte[] b = new byte[size];
+            int bytesRead = 0;
+
+            try {
+                //the only way to read data from android uri
+                bytesRead = getContentResolver().openInputStream(uri).read(b);
+
+                if(size==bytesRead)
+                {
+                    String path = global.getSubdirectory("Database");
+                    f = new File(path,"MasterData.rar");
+                    if(f.exists() || f.createNewFile())
+                        new FileOutputStream(f).write(b);
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
             ShowDialogTex2();
-
-//          getMasterDataText((f.getName()).toString());
-//            if(calledFrom == "java"){
-//                ConfirmDialog((f.getName()).toString());
-//            }else{
-//                ConfirmDialogPage((f.getName()).toString());
-//            }
-
-        }else if(requestCode == 4 && resultCode == 0){
+        } else if (requestCode == 4 && resultCode == 0) {
             finish();
-        }
-        else{//if user cancels
+        } else {//if user cancels
             ClientAndroidInterface.inProgress = false;
             this.InsureeNumber = null;
             this.ImagePath = null;
@@ -681,7 +687,7 @@ public class MainActivity extends AppCompatActivity
                             public void onClick(DialogInterface dialog, int id) {
                                 try {
                                     etRarPassword = userInput.getText().toString();
-                                    getMasterDataText2(f.getName(), etRarPassword);
+                                    getMasterDataText2(f.getPath(), etRarPassword);
 
                                     if(calledFrom == "java"){
                                         ConfirmDialog((f.getName()).toString());

--- a/app/src/main/java/org/openimis/imispolicies/SQLHandler.java
+++ b/app/src/main/java/org/openimis/imispolicies/SQLHandler.java
@@ -708,14 +708,12 @@ public class SQLHandler extends SQLiteOpenHelper {
                     object = array.getJSONObject(i);
                     ContentValues cv = new ContentValues();
                     for(String c: Columns){
-
                         cv.put(c,  object.getString(c));
                     }
                     mDatabase.insert(TableName,null,cv);
 
                 } catch (JSONException e) {
                     e.printStackTrace();
-                    throw e;
                 }
 
             }

--- a/app/src/main/java/org/openimis/imispolicies/Token.java
+++ b/app/src/main/java/org/openimis/imispolicies/Token.java
@@ -19,7 +19,7 @@ public class Token {
         if (!Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
             //handle case of no SDCARD present
         } else {
-            Global global = new Global();
+            Global global = Global.getGlobal();
             String dir = global.getSubdirectory("Authentications");
 
             File file = new File(dir, "token.txt");
@@ -43,7 +43,7 @@ public class Token {
     public String getTokenText() {
         String aBuffer = "";
         try {
-            Global global = new Global();
+            Global global = Global.getGlobal();
             String dir = global.getSubdirectory("Authentications");
             File myFile = new File(dir, "token.txt");
             if (myFile.exists()) {


### PR DESCRIPTION
Changes:
- Fixed how the file picker worked. Earlier it will only pull the file name, resulting in Master data import being possible only inside `IMIS/Database` directory. Now the file content is copied to app specific directory, so it can be fully managed.
- Added a solution to easily change privacy of specific IMIS subdirectories. Private directories will be created inside the `/data/` instead of `/storage/`. Moved `Authentications` and `Database` dirs to `/data/`
- Added a solution to get application context inside components that are not Android components. (i.e. `Token` class)

[https://openimis.atlassian.net/browse/OTC-75](https://openimis.atlassian.net/browse/OTC-75)