### PR TITLE
OTC-262: Use restapi when calling GetControlNumber api for CHF

### DIFF
--- a/app/src/main/java/org/openimis/imispolicies/NotEnrolledPoliciesOverview.java
+++ b/app/src/main/java/org/openimis/imispolicies/NotEnrolledPoliciesOverview.java
@@ -547,7 +547,11 @@ public class NotEnrolledPoliciesOverview extends AppCompatActivity {
         Thread thread = new Thread() {
             public void run() {
                 HttpClient httpClient = new DefaultHttpClient();
-                HttpPost httpPost = new HttpPost(AppInformation.DomainInfo.getDomain() + "payment/GetControlNumber");
+                String domain = AppInformation.DomainInfo.getDomain();
+                if (BuildConfig.API_BASE_URL.equals("http://chf-dev.swisstph-mis.ch/rest/") || BuildConfig.API_BASE_URL.equals("http://196.192.73.26/rest/")) {
+                    domain = domain.replace("/rest/", "/restapi/");
+                }
+                HttpPost httpPost = new HttpPost(domain + "api/GetControlNumber");
 // Request parameters and other properties.
                 try {
                     StringEntity postingString = new StringEntity(order.toString());

--- a/app/src/main/java/org/openimis/imispolicies/NotEnrolledPoliciesOverview.java
+++ b/app/src/main/java/org/openimis/imispolicies/NotEnrolledPoliciesOverview.java
@@ -548,7 +548,7 @@ public class NotEnrolledPoliciesOverview extends AppCompatActivity {
             public void run() {
                 HttpClient httpClient = new DefaultHttpClient();
                 String domain = AppInformation.DomainInfo.getDomain();
-                if (BuildConfig.API_BASE_URL.equals("http://chf-dev.swisstph-mis.ch/rest/") || BuildConfig.API_BASE_URL.equals("http://196.192.73.26/rest/")) {
+                if (BuildConfig.APPLICATION_ID .equals("org.openimis.imispolicies.chf") || BuildConfig.APPLICATION_ID.equals("org.openimis.imispolicies.poralguat")) {
                     domain = domain.replace("/rest/", "/restapi/");
                 }
                 HttpPost httpPost = new HttpPost(domain + "api/GetControlNumber");

--- a/app/src/main/java/org/openimis/imispolicies/OverViewPolicies.java
+++ b/app/src/main/java/org/openimis/imispolicies/OverViewPolicies.java
@@ -578,7 +578,7 @@ public class OverViewPolicies extends AppCompatActivity {
             public void run() {
                 HttpClient httpClient = new DefaultHttpClient();
                 String domain = AppInformation.DomainInfo.getDomain();
-                if (BuildConfig.API_BASE_URL.equals("http://chf-dev.swisstph-mis.ch/rest/") || BuildConfig.API_BASE_URL.equals("http://196.192.73.26/rest/")) {
+                if (BuildConfig.APPLICATION_ID .equals("org.openimis.imispolicies.chf") || BuildConfig.APPLICATION_ID.equals("org.openimis.imispolicies.poralguat")) {
                     domain = domain.replace("/rest/", "/restapi/");
                 }
                 HttpPost httpPost = new HttpPost(domain+"api/GetControlNumber");

--- a/app/src/main/java/org/openimis/imispolicies/OverViewPolicies.java
+++ b/app/src/main/java/org/openimis/imispolicies/OverViewPolicies.java
@@ -577,7 +577,11 @@ public class OverViewPolicies extends AppCompatActivity {
         Thread thread = new Thread(){
             public void run() {
                 HttpClient httpClient = new DefaultHttpClient();
-                HttpPost httpPost = new HttpPost(AppInformation.DomainInfo.getDomain()+"payment/GetControlNumber");
+                String domain = AppInformation.DomainInfo.getDomain();
+                if (BuildConfig.API_BASE_URL.equals("http://chf-dev.swisstph-mis.ch/rest/") || BuildConfig.API_BASE_URL.equals("http://196.192.73.26/rest/")) {
+                    domain = domain.replace("/rest/", "/restapi/");
+                }
+                HttpPost httpPost = new HttpPost(domain+"api/GetControlNumber");
 // Request parameters and other properties.
                 try {
                     StringEntity postingString = new StringEntity(order.toString());
@@ -599,7 +603,7 @@ public class OverViewPolicies extends AppCompatActivity {
 
                 HttpResponse response = null;
                 try {
-                    response = toRestApi.postToRestApiToken(order, "payment/GetControlNumber");
+                    response = httpClient.execute(httpPost);
 
                     HttpEntity respEntity = response.getEntity();
                     String content = null;


### PR DESCRIPTION
TICKET: https://openimis.atlassian.net/browse/OTC-262

Changes:
1. Process url path for "getControlNumber" from 'restapi' instead of 'rest' (for CHF and PORALG-UAT versions/builds). 