### PR TITLE
OP-354: Fix assigning photos to insurees in IMIS Policies

### DIFF
--- a/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
+++ b/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
@@ -73,6 +73,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
+import java.util.Arrays;
 import java.util.Date;
 
 
@@ -922,7 +923,7 @@ public class ClientAndroidInterface {
 
             String IdentificationType = "null";
             if (!TextUtils.isEmpty(data.get("ddlIdentificationType")) && !data.get("ddlIdentificationType").equals(""))
-                IdentificationType = (data.get("ddlIdentificationType")).toString();
+                IdentificationType = (data.get("ddlIdentificationType"));
 
             String PhotoPath = data.get("hfImagePath");
             String newPhotoPath = data.get("hfNewPhotoPath");
@@ -3160,7 +3161,7 @@ public class ClientAndroidInterface {
 
             if (IsOffline == 1) {
                 if (!getRule("AllowInsureeWithoutPhoto")) {
-                    if (PhotoPath.length() == 0 && PhotoPath.equals("null") && PhotoPath == null) {
+                    if (PhotoPath == null || PhotoPath.length() == 0 || PhotoPath.equals("null")) {
                         String chfid = (Insureeobject.getString("CHFID"));
                         String lastname = (Insureeobject.getString("LastName"));
                         String othername = (Insureeobject.getString("OtherNames"));
@@ -4606,19 +4607,14 @@ public class ClientAndroidInterface {
     @JavascriptInterface
     public String GetListOfImagesContain(final String FileName) {
         File[] Photos = null;
-        global = (Global) mContext.getApplicationContext();
+        String newFileName = "";
         File Directory = new File(global.getImageFolder());
 
-        FilenameFilter filter = new FilenameFilter() {
+        Photos = Directory.listFiles((dir,filename)->filename.startsWith(FileName + "_"));
 
-            @Override
-            public boolean accept(File dir, String filename) {
-                return filename.startsWith(FileName + "_");
-            }
-        };
-        Photos = Directory.listFiles(filter);
-        String newFileName = "";
-        if (Photos.length > 0) {
+        if(Photos!=null && Photos.length > 0)
+        {
+            Arrays.sort(Photos,(f1,f2)->f1.getName().compareTo(f2.getName()));
             newFileName = Photos[Photos.length - 1].toString();
         }
         return newFileName;

--- a/app/src/main/java/org/openimis/imispolicies/Global.java
+++ b/app/src/main/java/org/openimis/imispolicies/Global.java
@@ -54,7 +54,7 @@ public class Global extends Application {
     private String AppDirectory;
     private Map<String, String> SubDirectories = new HashMap<>();
 
-    private List<String> ProtectedDirectories = Arrays.asList("Authentications","Database");
+    private List<String> ProtectedDirectories = Arrays.asList("Authentications","Database","Images");
 
     public static Global getGlobal() {
         return GlobalContext;

--- a/app/src/main/java/org/openimis/imispolicies/MainActivity.java
+++ b/app/src/main/java/org/openimis/imispolicies/MainActivity.java
@@ -109,8 +109,8 @@ public class MainActivity extends AppCompatActivity
     private String selectedLanguage;
     public String ImagePath;
     public String InsureeNumber;
-    static   TextView Login;
-    static  TextView OfficerName;
+    static TextView Login;
+    static TextView OfficerName;
     ClientAndroidInterface ca;
     String aBuffer = "";
     String calledFrom = "java";
@@ -119,7 +119,7 @@ public class MainActivity extends AppCompatActivity
     General _General = new General(AppInformation.DomainInfo.getDomain());
 
     final String VersionField = "AppVersionImis";
-    final String ApkFileLocation = _General.getDomain() + "/Apps/IMIS.apk";
+    final String ApkFileLocation = AppInformation.DomainInfo.getDomain() + "/Apps/IMIS.apk";
     final int SIMPLE_NOTFICATION_ID = 98029;
 
     NotificationManager mNotificationManager;

--- a/app/src/main/java/org/openimis/imispolicies/SQLHandler.java
+++ b/app/src/main/java/org/openimis/imispolicies/SQLHandler.java
@@ -743,7 +743,8 @@ public class SQLHandler extends SQLiteOpenHelper {
     }
 
     public int updateData(String tableName, ContentValues contentValues, String whereClause, String[] whereArgs) throws UserException {
-        int rowsUpdated;
+        openDatabase();
+        int rowsUpdated = 0;
         try {
             openDatabase();
             rowsUpdated = mDatabase.update(tableName, contentValues, whereClause, whereArgs);
@@ -753,9 +754,9 @@ public class SQLHandler extends SQLiteOpenHelper {
             return rowsUpdated;
         } catch (Exception e) {
             e.printStackTrace();
-            throw e;
         } finally {
             closeDatabase();
+            return  rowsUpdated;
         }
     }
 


### PR DESCRIPTION
Changes

- Acquiring photo from menu now updates local insuree on submit
- Automatic photo assignment now picks the newest photo of a insuree
- Changed some event handlers to lambda expressions
- Deleted unused legace code related to `CallSoap`
- Fixed update call of `SQLHandler`

[https://openimis.atlassian.net/browse/OP-354](https://openimis.atlassian.net/browse/OP-354)