### PR TITLE
OTC-267: Enforce Send SMS to yes in CN request

### DIFF
--- a/app/src/main/res/layout/controls.xml
+++ b/app/src/main/res/layout/controls.xml
@@ -72,6 +72,7 @@
         android:id="@+id/send_sms"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:checked="true"
         android:layout_margin="10dp"/>
 
 


### PR DESCRIPTION
Changes:
- “Send SMS” checkbox in CN request checked by default

[https://openimis.atlassian.net/browse/OTC-267](https://openimis.atlassian.net/browse/OTC-267)