### PR TITLE
Fix token condition in searching families

### DIFF
--- a/app/src/main/assets/pages/Search.html
+++ b/app/src/main/assets/pages/Search.html
@@ -38,7 +38,7 @@ In case of dispute arising out or in relation to the use of the program, it is s
         document.title = Android.getString('Search');
         $('#spPleaseWait').text(Android.getString('DownloadFamily'));
 
-         if(Android.isLoggedIn()){
+         if(!Android.isLoggedIn()){
            window.open("Login.html?s=1", "_self");
          }
 


### PR DESCRIPTION
Currently used condition is opening login prompt when loged user tried to enter 'modify family' activity. Because of that user could never open the activity.