### PR TITLE
OTC-309: If picture is taken with Acquire, it is not displayed with Enrol a new insuree with same CHFID

### DIFF
--- a/app/src/main/java/org/openimis/imispolicies/MainActivity.java
+++ b/app/src/main/java/org/openimis/imispolicies/MainActivity.java
@@ -294,6 +294,7 @@ public class MainActivity extends AppCompatActivity
         settings.setLayoutAlgorithm(WebSettings.LayoutAlgorithm.SINGLE_COLUMN);
         settings.setUseWideViewPort(true);
         settings.setSaveFormData(true);
+        settings.setAllowFileAccess(true);
         //noinspection deprecation
         settings.setEnableSmoothTransition(true);
         settings.setLoadWithOverviewMode(true);


### PR DESCRIPTION
Changed:
- Set the `AllowFileAccess` flag to `true` in `WebView` initialization, as it can be set to `false` by default depending on Android version and phone manufacturer.

[https://openimis.atlassian.net/browse/OTC-309](https://openimis.atlassian.net/browse/OTC-309)