### PR TITLE
OTC-313: Fixed issue with saving families pulled from server

### DIFF
--- a/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
+++ b/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
@@ -1252,7 +1252,9 @@ public class ClientAndroidInterface {
 //            outputStream.close();
 
             OutputStream outputStream = ResizeImage(selectedPath, outputFileName, 400);
-            assert outputStream != null;
+            if (outputStream == null) {
+                throw new IOException("Family photo output stream is empty");
+            }
             outputStream.flush();
             outputStream.close();
             return outputFileName;


### PR DESCRIPTION
TICKET: [OTC-313](https://openimis.atlassian.net/browse/OTC-313)
Assertion instead of exception caused execution freezing. 