### PR TITLE
OTC-325: If there is an error when requesting CN, the state of policies should remain the same

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
-    package="org.openimis.imispolicies"
-    >
+    package="org.openimis.imispolicies">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
@@ -15,34 +14,42 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE"/>
-
-    <uses-permission android:name="android.permission.READ_CALL_LOG" tools:node="remove" />
-    <uses-permission android:name="android.permission.READ_CONTACTS" tools:node="remove" />
+    <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission
+        android:name="android.permission.READ_CALL_LOG"
+        tools:node="remove" />
+    <uses-permission
+        android:name="android.permission.READ_CONTACTS"
+        tools:node="remove" />
 
     <uses-feature
         android:name="android.hardware.camera"
         android:required="true" />
 
     <application
-        android:name="org.openimis.imispolicies.Global"
+        android:name=".Global"
         android:allowBackup="true"
         android:fullBackupContent="@xml/backup_descriptor"
-        android:networkSecurityConfig="@xml/network_security_config"
+        android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher_policies"
         android:label="@string/app_name_policies"
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:requestLegacyExternalStorage="true"
         android:roundIcon="@mipmap/ic_launcher_policies"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        android:requestLegacyExternalStorage="true"
-        android:hardwareAccelerated="true"
         tools:ignore="GoogleAppIndexingWarning"
         tools:replace="android:icon,android:label">
+        <service
+            android:name=".ControlNumberService"
+            android:exported="false"></service>
+
         <uses-library
             android:name="org.apache.http.legacy"
-            android:required="false"/>
+            android:required="false" />
+
         <activity
-            android:name="org.openimis.imispolicies.MainActivity"
+            android:name=".MainActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/app_name_policies"
             android:screenOrientation="portrait"
@@ -54,64 +61,65 @@
             </intent-filter>
         </activity>
         <activity
-            android:name="org.openimis.imispolicies.Enquire"
+            android:name=".Enquire"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/Enquire"
             android:screenOrientation="portrait" />
         <activity
-            android:name="org.openimis.imispolicies.RenewList"
+            android:name=".RenewList"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/Renewal"
             android:screenOrientation="portrait" />
         <activity
-            android:name="org.openimis.imispolicies.Renewal"
+            android:name=".Renewal"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/Renewal"
-            android:parentActivityName="org.openimis.imispolicies.RenewList"
+            android:parentActivityName=".RenewList"
             android:screenOrientation="portrait"
             tools:targetApi="jelly_bean" />
         <activity
-            android:name="org.openimis.imispolicies.FeedbackList"
+            android:name=".FeedbackList"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:screenOrientation="portrait" />
         <activity
-            android:name="org.openimis.imispolicies.Feedback"
+            android:name=".Feedback"
             android:configChanges="keyboardHidden|orientation|screenSize"
-            android:parentActivityName="org.openimis.imispolicies.FeedbackList"
+            android:parentActivityName=".FeedbackList"
             android:screenOrientation="portrait"
             tools:targetApi="jelly_bean" />
         <activity
-            android:name="org.openimis.imispolicies.Statistics"
+            android:name=".Statistics"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:screenOrientation="portrait" />
         <activity
-            android:name="org.openimis.imispolicies.Acquire"
+            android:name=".Acquire"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/Acquire"
             android:screenOrientation="portrait" />
-        <activity android:name="org.openimis.imispolicies.Reports"
+        <activity
+            android:name=".Reports"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/Reports"
             android:screenOrientation="portrait" />
         <activity
-            android:name="org.openimis.imispolicies.SnapshotIndicators"
+            android:name=".SnapshotIndicators"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/SnapshotIndicators"
             android:screenOrientation="portrait" />
-
-        <activity android:name="org.openimis.imispolicies.CumulativeIndicators"
+        <activity
+            android:name=".CumulativeIndicators"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/CumulativeIndicators"
             android:screenOrientation="portrait" />
-        <activity android:name="org.openimis.imispolicies.PaymentOverview" />
-        <activity android:name="org.openimis.imispolicies.SearchOverViewPolicies" />
-        <activity android:name="org.openimis.imispolicies.OverViewPolicies" />
-        <activity android:name="org.openimis.imispolicies.OverViewControlNumbers" />
-        <activity android:name="org.openimis.imispolicies.SearchOverViewControlNumber" />
-        <activity android:name="org.openimis.imispolicies.ViewPolicies" />
-        <activity android:name="org.openimis.imispolicies.CheckCommission" />
-        <activity android:name="org.openimis.imispolicies.SearchNotEnrolledPolicies" />
-        <activity android:name="org.openimis.imispolicies.NotEnrolledPoliciesOverview" />
+        <activity android:name=".PaymentOverview" />
+        <activity android:name=".SearchOverViewPolicies" />
+        <activity android:name=".OverViewPolicies" />
+        <activity android:name=".OverViewControlNumbers" />
+        <activity android:name=".SearchOverViewControlNumber" />
+        <activity android:name=".ViewPolicies" />
+        <activity android:name=".CheckCommission" />
+        <activity android:name=".SearchNotEnrolledPolicies" />
+        <activity android:name=".NotEnrolledPoliciesOverview" />
     </application>
 
 </manifest>

--- a/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
+++ b/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
@@ -2353,7 +2353,7 @@ public class ClientAndroidInterface {
         return RecordedPolicies.toString();
     }
 
-    public int insertRecordedPolicy(String amountCalculated, String amountConfirmed, String control_number, String InternalIdentifier, String PaymentType, String SmsRequired) {
+    public int insertControlNumber(String amountCalculated, String amountConfirmed, String control_number, String InternalIdentifier, String PaymentType, String SmsRequired) {
         ContentValues values = new ContentValues();
         values.put("AmountCalculated", String.valueOf(amountCalculated));
         values.put("AmountConfirmed", String.valueOf(amountConfirmed));

--- a/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
+++ b/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
@@ -6484,7 +6484,7 @@ public class ClientAndroidInterface {
         }
 
         String query = "SELECT * FROM tblRecordedPolicies WHERE InsuranceNumber LIKE '%" + insuranceNumber +
-                "%' AND ProductCode LIKE '%" + insuranceProduct + "%' " + aRenewal + " AND UploadedDate == '' AND typeof(ControlNumberId) != 'integer'";
+                "%' AND ProductCode LIKE '%" + insuranceProduct + "%' " + aRenewal + " AND UploadedDate == ''";
         JSONArray notEnrolledPolicies = sqlHandler.getResult(query, null);
         return notEnrolledPolicies;
     }

--- a/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
+++ b/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
@@ -2253,8 +2253,8 @@ public class ClientAndroidInterface {
 
     public JSONArray getRecordedPolicies(String insuranceNumber, String otherNames, String lastName, String insuranceProduct, String uploadedFrom, String uploadedTo, String radioRenewal, String requestedFrom, String requestedTo, String PaymentType) {
         String renewal = "";
-        String request = "";
-        String upload = "";
+        String request;
+        String upload;
         String payment_type = "";
 
         if (!radioRenewal.equals("")) {
@@ -2273,8 +2273,14 @@ public class ClientAndroidInterface {
         String dateRequestedFrom = getOrDefault(requestedFrom, earlyDate);
         String dateRequestedTo = getOrDefault(requestedTo, today);
 
-        upload = " AND RP.UploadedDate BETWEEN '" + dateUploadedFrom + "' AND '" + dateUploadedTo + "'";
-        request = " AND RP.UploadedDate BETWEEN '" + dateRequestedFrom + "' AND '" + dateRequestedTo + "'";
+        if("".equals(uploadedFrom) && "".equals(uploadedTo))
+        {
+            upload = "";
+        } else {
+            upload = " AND RP.UploadedDate BETWEEN '" + dateUploadedFrom + "' AND '" + dateUploadedTo + "'";
+        }
+
+        request = " AND RP.ControlRequestDate BETWEEN '" + dateRequestedFrom + "' AND '" + dateRequestedTo + "'";
 
         String Query = "SELECT * FROM tblRecordedPolicies RP INNER JOIN tblControlNumber CN ON RP.ControlNumberId = CN.Id WHERE RP.InsuranceNumber LIKE '%" + insuranceNumber + "%' AND RP.LastName LIKE '%" + lastName + "%' AND RP.OtherNames LIKE '%" + otherNames + "%' AND RP.ProductCode LIKE '%" + insuranceProduct + "%'" + renewal + " " + request + " " + upload + " " + payment_type + "";
         JSONArray RecordedPolicies = sqlHandler.getResult(Query, null);

--- a/app/src/main/java/org/openimis/imispolicies/ControlNumberService.java
+++ b/app/src/main/java/org/openimis/imispolicies/ControlNumberService.java
@@ -1,0 +1,184 @@
+package org.openimis.imispolicies;
+
+import android.app.IntentService;
+import android.content.Intent;
+import android.content.Context;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.util.EntityUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+public class ControlNumberService extends IntentService {
+
+    private static final String ACTION_REQUEST_CN = "ControlNumberService.ACTION_REQUEST_CN";
+    private static final String ACTION_GET_ASSIGNED_CN = "ControlNumberService.ACTION_GET_ASSIGNED_CN";
+
+    private static final String FIELD_PAYLOAD = "FIELD_PAYLOAD";
+    private static final String FIELD_PAYMENT_DETAILS = "FIELD_PAYMENT_DETAILS";
+
+    public static final String ACTION_REQUEST_SUCCESS = "ControlNumberService.ACTION_REQUEST_SUCCESS";
+    public static final String ACTION_REQUEST_ERROR = "ControlNumberService.ACTION_REQUEST_ERROR";
+
+    public static final String FIELD_ERROR_MESSAGE = "FIELD_ERROR_MESSAGE";
+
+    private ToRestApi toRestApi;
+    private ClientAndroidInterface ca;
+
+    public ControlNumberService() {
+        super("ControlNumberService");
+    }
+
+    public static void requestControlNumber(Context context, final JSONObject order, final JSONArray paymentDetails) {
+        Intent intent = new Intent(context, ControlNumberService.class);
+        intent.setAction(ACTION_REQUEST_CN);
+        intent.putExtra(FIELD_PAYLOAD, order.toString());
+        intent.putExtra(FIELD_PAYMENT_DETAILS, paymentDetails.toString());
+        context.startService(intent);
+    }
+
+    public static void getAssignedControlNumber(Context context, final JSONArray order) {
+        Intent intent = new Intent(context, ControlNumberService.class);
+        intent.setAction(ACTION_GET_ASSIGNED_CN);
+        intent.putExtra(FIELD_PAYLOAD, order.toString());
+        context.startService(intent);
+    }
+
+    @Override
+    protected void onHandleIntent(Intent intent) {
+        toRestApi = new ToRestApi();
+        ca = new ClientAndroidInterface(this);
+
+        if (intent != null) {
+            final String action = intent.getAction();
+            if (ACTION_REQUEST_CN.equals(action)) {
+                final String order = intent.getStringExtra(FIELD_PAYLOAD);
+                final String details = intent.getStringExtra(FIELD_PAYMENT_DETAILS);
+                handleActionRequestCN(order, details);
+            } else if (ACTION_GET_ASSIGNED_CN.equals(action)) {
+                final String order = intent.getStringExtra(FIELD_PAYLOAD);
+                handleActionGetAssignedCN(order);
+            }
+        }
+    }
+
+    private void handleActionRequestCN(final String order, final String details) {
+        String errorMessage;
+        try {
+            JSONObject orderJson = new JSONObject(order);
+            JSONArray detailsJson = new JSONArray(details);
+
+            HttpEntity respEntity;
+            HttpResponse response = toRestApi.postToRestApiToken(orderJson, "GetControlNumber");
+            int responseCode = response.getStatusLine().getStatusCode();
+            respEntity = response.getEntity();
+            String content = EntityUtils.toString(respEntity);
+
+            JSONObject responseContent = new JSONObject(content);
+            errorMessage = getErrorMessage(responseCode, responseContent);
+
+            if ("".equals(errorMessage)) {
+                String internalIdentifier = responseContent.getString("internal_identifier");
+                String controlNumber = responseContent.getString("control_number");
+                int id = insertControlNumber(orderJson, controlNumber, internalIdentifier);
+                updateRecordedPoliciesAfterRequest(detailsJson, id);
+
+                broadcastSuccess();
+            } else {
+                broadcastError(errorMessage);
+            }
+        } catch (IOException | JSONException e) {
+            e.printStackTrace();
+            broadcastError(getResources().getString(R.string.SomethingWrongServer));
+        }
+    }
+
+    private void handleActionGetAssignedCN(final String order) {
+        String errorMessage;
+        try {
+            JSONObject orderJson = new JSONObject().put("requests", new JSONArray(order));
+
+            HttpEntity respEntity;
+            HttpResponse response = toRestApi.postToRestApiToken(orderJson, "GetAssignedControlNumbers");
+            int responseCode = response.getStatusLine().getStatusCode();
+            respEntity = response.getEntity();
+            String content = EntityUtils.toString(respEntity);
+
+            JSONObject responseContent = new JSONObject(content);
+            errorMessage = getErrorMessage(responseCode, responseContent);
+            if ("".equals(errorMessage)) {
+                String assignedControlNumbers = responseContent.getString("assigned_control_numbers");
+                updateAssignedControlNumbers(assignedControlNumbers);
+
+                broadcastSuccess();
+            } else {
+                broadcastError(errorMessage);
+            }
+        } catch (IOException | JSONException e) {
+            e.printStackTrace();
+            broadcastError(getResources().getString(R.string.SomethingWrongServer));
+        }
+    }
+
+    private void broadcastSuccess() {
+        Intent successIntent = new Intent(ACTION_REQUEST_SUCCESS);
+        sendBroadcast(successIntent);
+    }
+
+    private void broadcastError(String errorMessage) {
+        Intent errorIntent = new Intent(ACTION_REQUEST_ERROR);
+        errorIntent.putExtra(FIELD_ERROR_MESSAGE, errorMessage);
+        sendBroadcast(errorIntent);
+    }
+
+    private String getErrorMessage(int responseCode, JSONObject responseContent) throws JSONException {
+        String errorMessage;
+        if ("true".equals(responseContent.getString("error_occured"))) {
+            errorMessage = responseContent.getString("error_message");
+        } else if (responseCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
+            errorMessage = getResources().getString(R.string.has_no_rights);
+        } else if (responseCode == HttpURLConnection.HTTP_INTERNAL_ERROR) {
+            errorMessage = getResources().getString(R.string.SomethingWrongServer);
+        } else if (responseCode >= 400) { // for compatibility, but should not be needed
+            errorMessage = getResources().getString(R.string.SomethingWrongServer);
+        } else {
+            errorMessage = "";
+        }
+        return errorMessage;
+    }
+
+    private int insertControlNumber(JSONObject order, String controlNumber, String internalIdentifier) throws JSONException {
+        return ca.insertControlNumber(
+                order.getString("amount_to_be_paid"),
+                order.getString("amount_to_be_paid"), //TODO no separation between calculated and confirmed amount for now
+                controlNumber,
+                internalIdentifier,
+                order.getString("type_of_payment"),
+                order.getString("SmsRequired"));
+    }
+
+    private void updateRecordedPoliciesAfterRequest(JSONArray paymentDetails, int ControlNumberId) throws JSONException {
+        JSONObject ob;
+        for (int j = 0; j < paymentDetails.length(); j++) {
+            ob = paymentDetails.getJSONObject(j);
+            int Id = Integer.parseInt(ob.getString("Id"));
+            ca.updateRecordedPolicy(Id, ControlNumberId);
+        }
+    }
+
+    private void updateAssignedControlNumbers(String assignedControlNumbers) throws JSONException {
+        JSONObject ob;
+        JSONArray arr = new JSONArray(assignedControlNumbers);
+        for (int j = 0; j < arr.length(); j++) {
+            ob = arr.getJSONObject(j);
+            String internalIdentifier = ob.getString("internal_identifier");
+            String controlNumber = ob.getString("control_number");
+            ca.assignControlNumber(internalIdentifier, controlNumber);
+        }
+    }
+}

--- a/app/src/main/java/org/openimis/imispolicies/NotEnrolledPoliciesOverview.java
+++ b/app/src/main/java/org/openimis/imispolicies/NotEnrolledPoliciesOverview.java
@@ -517,7 +517,7 @@ public class NotEnrolledPoliciesOverview extends AppCompatActivity {
 
     private void handleRequestResult(Intent intent) {
         if (intent.getAction().equals(ControlNumberService.ACTION_REQUEST_SUCCESS)) {
-            showSnackbar(getResources().getString(R.string.requestSent));
+            policyDeleteDialogReport(getResources().getString(R.string.requestSent));
         }
         else if (intent.getAction().equals(ControlNumberService.ACTION_REQUEST_ERROR)) {
             String errorMessage = intent.getStringExtra(ControlNumberService.FIELD_ERROR_MESSAGE);

--- a/app/src/main/java/org/openimis/imispolicies/NotEnrolledPoliciesOverview.java
+++ b/app/src/main/java/org/openimis/imispolicies/NotEnrolledPoliciesOverview.java
@@ -486,64 +486,62 @@ public class NotEnrolledPoliciesOverview extends AppCompatActivity {
     }
 
     private int getControlNumber(final JSONObject order, final String SmsRequired) {
-        new Thread() {
-            public void run() {
-                runOnUiThread(() -> pd = ProgressDialog.show(NotEnrolledPoliciesOverview.this, "", getResources().getString(R.string.Get_Control_Number)));
+        new Thread(() -> {
+            runOnUiThread(() -> pd = ProgressDialog.show(NotEnrolledPoliciesOverview.this, "", getResources().getString(R.string.Get_Control_Number)));
 
-                HttpResponse response;
-                try {
-                    response = toRestApi.postToRestApiToken(order, "GetControlNumber");
-                    int code = response.getStatusLine().getStatusCode();
+            HttpResponse response;
+            try {
+                response = toRestApi.postToRestApiToken(order, "GetControlNumber");
+                int code = response.getStatusLine().getStatusCode();
 
-                    HttpEntity respEntity = response.getEntity();
-                    String content;
-                    if (respEntity != null) {
-                        final String[] error_occured = {null};
-                        final String[] error_message = {null};
-                        final String[] internal_Identifier = {null};
-                        final String[] control_number = {null};
-                        // EntityUtils to get the response content
-                        content = EntityUtils.toString(respEntity);
+                HttpEntity respEntity = response.getEntity();
+                String content;
+                if (respEntity != null) {
+                    final String[] error_occured = {null};
+                    final String[] error_message = {null};
+                    final String[] internal_Identifier = {null};
+                    final String[] control_number = {null};
+                    // EntityUtils to get the response content
+                    content = EntityUtils.toString(respEntity);
 
-                        try {
-                            JSONObject res = new JSONObject(content);
+                    try {
+                        JSONObject res = new JSONObject(content);
 
-                            error_occured[0] = res.getString("error_occured");
-                            if ("true".equals(error_occured[0])) {
-                                error_message[0] = res.getString("error_message");
-                                showSnackbar(error_message[0]);
-                            } else if (code == HttpURLConnection.HTTP_UNAUTHORIZED) {
-                                LoginDialogBox();
-                                showSnackbar(getResources().getString(R.string.has_no_rights));
-                            } else if (code == HttpURLConnection.HTTP_INTERNAL_ERROR) {
-                                showSnackbar(getResources().getString(R.string.SomethingWrongServer));
-                            } else if (code >= 400) { // for compatibility, but should not be needed
-                                showSnackbar(getResources().getString(R.string.SomethingWrongServer));
-                            } else {
-                                internal_Identifier[0] = res.getString("internal_identifier");
-                                control_number[0] = res.getString("control_number");
-                                int id = insertAfterRequest(amountConfirmed, control_number[0], internal_Identifier[0], PaymentType, SmsRequired);
-                                updateAfterRequest(id);
-                                runOnUiThread(() -> {
-                                    pd.dismiss();
-                                    num.clear();
-                                    policyDeleteDialogReport(getResources().getString(R.string.requestSent));
-                                });
-                            }
-                        } catch (JSONException e) {
-                            runOnUiThread(() -> pd.dismiss());
+                        error_occured[0] = res.getString("error_occured");
+                        if ("true".equals(error_occured[0])) {
+                            error_message[0] = res.getString("error_message");
+                            showSnackbar(error_message[0]);
+                        } else if (code == HttpURLConnection.HTTP_UNAUTHORIZED) {
+                            LoginDialogBox();
+                            showSnackbar(getResources().getString(R.string.has_no_rights));
+                        } else if (code == HttpURLConnection.HTTP_INTERNAL_ERROR) {
                             showSnackbar(getResources().getString(R.string.SomethingWrongServer));
+                        } else if (code >= 400) { // for compatibility, but should not be needed
+                            showSnackbar(getResources().getString(R.string.SomethingWrongServer));
+                        } else {
+                            internal_Identifier[0] = res.getString("internal_identifier");
+                            control_number[0] = res.getString("control_number");
+                            int id = insertAfterRequest(amountConfirmed, control_number[0], internal_Identifier[0], PaymentType, SmsRequired);
+                            updateAfterRequest(id);
+                            runOnUiThread(() -> {
+                                num.clear();
+                                policyDeleteDialogReport(getResources().getString(R.string.requestSent));
+                            });
                         }
-                    } else {
                         runOnUiThread(() -> pd.dismiss());
-                        showSnackbar(getResources().getString(R.string.NoInternet));
+                    } catch (JSONException e) {
+                        runOnUiThread(() -> pd.dismiss());
+                        showSnackbar(getResources().getString(R.string.SomethingWrongServer));
                     }
-                } catch (IOException e) {
+                } else {
                     runOnUiThread(() -> pd.dismiss());
                     showSnackbar(getResources().getString(R.string.NoInternet));
                 }
+            } catch (IOException e) {
+                runOnUiThread(() -> pd.dismiss());
+                showSnackbar(getResources().getString(R.string.NoInternet));
             }
-        }.start();
+        }).start();
 
         return 0;
     }

--- a/app/src/main/java/org/openimis/imispolicies/OverViewControlNumbers.java
+++ b/app/src/main/java/org/openimis/imispolicies/OverViewControlNumbers.java
@@ -445,8 +445,7 @@ public class OverViewControlNumbers extends AppCompatActivity {
 
     private void handleRequestResult(Intent intent) {
         if (intent.getAction().equals(ControlNumberService.ACTION_REQUEST_SUCCESS)) {
-            showSnackbar(getResources().getString(R.string.requestSent));
-            refresh();
+            policyDeleteDialogReport(getResources().getString(R.string.requestSent));
         } else if (intent.getAction().equals(ControlNumberService.ACTION_REQUEST_ERROR)) {
             String errorMessage = intent.getStringExtra(ControlNumberService.FIELD_ERROR_MESSAGE);
             showSnackbar(errorMessage);

--- a/app/src/main/java/org/openimis/imispolicies/OverViewControlNumbers.java
+++ b/app/src/main/java/org/openimis/imispolicies/OverViewControlNumbers.java
@@ -497,8 +497,7 @@ public class OverViewControlNumbers extends AppCompatActivity {
                 runOnUiThread(() -> pd.dismiss());
                 showSnackbar(getResources().getString(R.string.NoInternet));
             }
-        }
-        ).start();
+        }).start();
 
         return 0;
     }

--- a/app/src/main/java/org/openimis/imispolicies/OverViewControlNumbers.java
+++ b/app/src/main/java/org/openimis/imispolicies/OverViewControlNumbers.java
@@ -3,7 +3,10 @@ package org.openimis.imispolicies;
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -78,6 +81,31 @@ public class OverViewControlNumbers extends AppCompatActivity {
     String RadioRenewal = "";
     String RadioSms = "";
     String PaymentType = "";
+
+    BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            handleRequestResult(intent);
+        }
+    };
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        IntentFilter intentFilter = new IntentFilter();
+        intentFilter.addAction(ControlNumberService.ACTION_REQUEST_SUCCESS);
+        intentFilter.addAction(ControlNumberService.ACTION_REQUEST_ERROR);
+
+        registerReceiver(broadcastReceiver, intentFilter);
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+
+        unregisterReceiver(broadcastReceiver);
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -257,22 +285,7 @@ public class OverViewControlNumbers extends AppCompatActivity {
         alertDialogBuilder
                 .setCancelable(false)
                 .setPositiveButton(getResources().getString(R.string.button_ok),
-                        (dialog, id) -> {
-                            finish();
-                            Intent intent = new Intent(OverViewControlNumbers.this, OverViewControlNumbers.class);
-                            intent.putExtra("RENEWAL", RadioRenewal);
-                            intent.putExtra("INSURANCE_NUMBER", InsuranceNumber);
-                            intent.putExtra("OTHER_NAMES", OtherNames);
-                            intent.putExtra("LAST_NAME", LastName);
-                            intent.putExtra("INSURANCE_PRODUCT", InsuranceProduct);
-                            intent.putExtra("UPLOADED_FROM", UploadedFrom);
-                            intent.putExtra("UPLOADED_TO", UploadedTo);
-                            intent.putExtra("REQUESTED_FROM", RequestedFrom);
-                            intent.putExtra("REQUESTED_TO", RequestedTo);
-                            intent.putExtra("PAYMENT_TYPE", PaymentType);
-                            intent.putExtra("SMS", RadioSms);
-                            startActivity(intent);
-                        });
+                        (dialog, id) -> refresh());
 
         // create alert dialog
         AlertDialog alertDialog = alertDialogBuilder.create();
@@ -425,93 +438,30 @@ public class OverViewControlNumbers extends AppCompatActivity {
         alertDialog.show();
     }
 
-    private int getControlNumber(final JSONArray order) {
-        final JSONObject jsonObject = new JSONObject();
-
-        try {
-            jsonObject.put("requests", order);
-        } catch (JSONException e) {
-            e.printStackTrace();
-        }
-        new Thread(() -> {
-            runOnUiThread(() -> pd = ProgressDialog.show(OverViewControlNumbers.this, "", getResources().getString(R.string.Get_Control_Number)));
-
-            HttpResponse response;
-            try {
-                response = toRestApi.postToRestApiToken(jsonObject, "GetAssignedControlNumbers");
-
-                HttpEntity respEntity = response.getEntity();
-
-                int code = response.getStatusLine().getStatusCode();
-
-                if (respEntity != null) {
-                    final String[] error_occured = {null};
-                    final String[] error_message = {null};
-                    final String[] internal_Identifier = {null};
-                    final String[] control_number = {null};
-                    // EntityUtils to get the response content
-                    String content;
-                    content = EntityUtils.toString(respEntity);
-
-                    try {
-                        JSONObject res = new JSONObject(content);
-
-                        error_occured[0] = res.getString("error_occured");
-                        if ("true".equals(error_occured[0])) {
-                            error_message[0] = res.getString("error_message");
-                            showSnackbar(error_message[0]);
-                        } else if (code == HttpURLConnection.HTTP_UNAUTHORIZED) {
-                            LoginDialogBox();
-                            showSnackbar(getResources().getString(R.string.has_no_rights));
-                        } else if (code == HttpURLConnection.HTTP_INTERNAL_ERROR) {
-                            showSnackbar(getResources().getString(R.string.SomethingWrongServer));
-                        } else if (code >= 400) { // for compatibility, but should not be needed
-                            showSnackbar(getResources().getString(R.string.SomethingWrongServer));
-                        } else {
-                            JSONObject ob;
-                            String assignedcontrolnumbers = res.getString("assigned_control_numbers");
-                            JSONArray arr = new JSONArray(assignedcontrolnumbers);
-                            for (int j = 0; j < arr.length(); j++) {
-                                try {
-                                    ob = arr.getJSONObject(j);
-                                    internal_Identifier[0] = ob.getString("internal_identifier");
-                                    control_number[0] = ob.getString("control_number");
-                                    updateAfterRequest(internal_Identifier[0], control_number[0]);
-                                } catch (JSONException e) {
-                                    e.printStackTrace();
-                                    showSnackbar(String.valueOf(e));
-                                }
-                            }
-                            runOnUiThread(() -> policyDeleteDialogReport(getResources().getString(R.string.requestSent)));
-                        }
-                        runOnUiThread(() -> pd.dismiss());
-                    } catch (JSONException e) {
-                        runOnUiThread(() -> pd.dismiss());
-                        showSnackbar(getResources().getString(R.string.SomethingWrongServer));
-                    }
-                } else {
-                    runOnUiThread(() -> pd.dismiss());
-                    showSnackbar(getResources().getString(R.string.NoInternet));
-                }
-            } catch (IOException e) {
-                runOnUiThread(() -> pd.dismiss());
-                showSnackbar(getResources().getString(R.string.NoInternet));
-            }
-        }).start();
-
-        return 0;
+    private void getControlNumber(final JSONArray order) {
+        pd = ProgressDialog.show(this, "", getResources().getString(R.string.Get_Control_Number));
+        ControlNumberService.getAssignedControlNumber(this, order);
     }
 
-    public void showSnackbar(String message)
-    {
+    private void handleRequestResult(Intent intent) {
+        if (intent.getAction().equals(ControlNumberService.ACTION_REQUEST_SUCCESS)) {
+            showSnackbar(getResources().getString(R.string.requestSent));
+            refresh();
+        } else if (intent.getAction().equals(ControlNumberService.ACTION_REQUEST_ERROR)) {
+            String errorMessage = intent.getStringExtra(ControlNumberService.FIELD_ERROR_MESSAGE);
+            showSnackbar(errorMessage);
+        }
+        pd.dismiss();
+    }
+
+    public void showSnackbar(String message) {
         View activity = findViewById(R.id.actv);
         Snackbar.make(activity, message, Snackbar.LENGTH_LONG)
                 .setAction("Action", null).show();
     }
 
-
-    private void updateAfterRequest(String InternalIdentifier, String ControlNumber) {
-        clientAndroidInterface.assignControlNumber(InternalIdentifier, ControlNumber);
+    public void refresh() {
+        finish();
+        startActivity(getIntent());
     }
 }
-

--- a/app/src/main/java/org/openimis/imispolicies/OverViewPolicies.java
+++ b/app/src/main/java/org/openimis/imispolicies/OverViewPolicies.java
@@ -515,8 +515,7 @@ public class OverViewPolicies extends AppCompatActivity {
 
     private void handleRequestResult(Intent intent) {
         if (intent.getAction().equals(ControlNumberService.ACTION_REQUEST_SUCCESS)) {
-            showSnackbar(getResources().getString(R.string.requestSent));
-            refresh();
+            policyDeleteDialogReport(getResources().getString(R.string.requestSent));
         } else if (intent.getAction().equals(ControlNumberService.ACTION_REQUEST_ERROR)) {
             String errorMessage = intent.getStringExtra(ControlNumberService.FIELD_ERROR_MESSAGE);
             showSnackbar(errorMessage);

--- a/app/src/main/java/org/openimis/imispolicies/OverViewPolicies.java
+++ b/app/src/main/java/org/openimis/imispolicies/OverViewPolicies.java
@@ -2,7 +2,10 @@ package org.openimis.imispolicies;
 
 import android.annotation.SuppressLint;
 import android.app.AlertDialog;
+import android.content.BroadcastReceiver;
+import android.content.Context;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.support.design.widget.Snackbar;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -12,6 +15,7 @@ import android.support.v7.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.CheckBox;
@@ -83,6 +87,31 @@ public class OverViewPolicies extends AppCompatActivity {
     String RadioRenewal = "";
     String RadioRequested = "";
     static String PayType = "";
+
+    BroadcastReceiver broadcastReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            handleRequestResult(intent);
+        }
+    };
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        IntentFilter intentFilter = new IntentFilter();
+        intentFilter.addAction(ControlNumberService.ACTION_REQUEST_SUCCESS);
+        intentFilter.addAction(ControlNumberService.ACTION_REQUEST_ERROR);
+
+        registerReceiver(broadcastReceiver, intentFilter);
+    }
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+
+        unregisterReceiver(broadcastReceiver);
+    }
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -283,8 +312,6 @@ public class OverViewPolicies extends AppCompatActivity {
             amount.setEnabled(false);
         }
 
-        final EditText finalAmount = promptsView.findViewById(R.id.display);
-
         // set dialog message
         alertDialogBuilder
                 .setCancelable(false)
@@ -292,16 +319,18 @@ public class OverViewPolicies extends AppCompatActivity {
                         (dialog, id) -> {
                             try {
                                 policies.put("phone_number", phoneNumber.getText().toString());
-                                policies.put("amount_to_be_paid", finalAmount.getText().toString());
+                                policies.put("amount_to_be_paid", amount.getText().toString());
                                 policies.put("SmsRequired", SmsRequired);
 
-                                if (PayType.toString().equals("Mobile Phone")) {
+                                if (PayType.equals("Mobile Phone")) {
                                     policies.put("type_of_payment", "MobilePhone");
-                                } else if (PayType.toString().equals("Bank Transfer")) {
+                                } else if (PayType.equals("Bank Transfer")) {
                                     policies.put("type_of_payment", "BankTransfer");
+                                } else {
+                                    policies.put("type_of_payment", "");
                                 }
-                                amountConfirmed = finalAmount.getText().toString();
-                                PaymentType = PayType.toString();
+                                amountConfirmed = amount.getText().toString();
+                                PaymentType = PayType;
 
                                 if (SmsRequired == 1 && phoneNumber.getText().toString().equals("")) {
                                     clientAndroidInterface.ShowDialog(getResources().getString(R.string.phone_number_not_provided));
@@ -309,7 +338,7 @@ public class OverViewPolicies extends AppCompatActivity {
                                     if (!clientAndroidInterface.isProductsListUnique(policies)) {
                                         policyDeleteDialogReport(getResources().getString(R.string.not_unique_products));
                                     } else {
-                                        getControlNumber(policies, String.valueOf(SmsRequired));
+                                        getControlNumber(policies);
                                     }
                                 }
                             } catch (JSONException e) {
@@ -341,7 +370,16 @@ public class OverViewPolicies extends AppCompatActivity {
     }
 
     public void addListenerOnSpinnerItemSelection(Spinner PaymentSpinner) {
-        PaymentSpinner.setOnItemSelectedListener(new CustomOnItemSelectedListener());
+        PaymentSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener() {
+            @Override
+            public void onItemSelected(AdapterView<?> parent, View view, int position, long id) {
+                PayType = parent.getItemAtPosition(position).toString();
+            }
+
+            @Override
+            public void onNothingSelected(AdapterView<?> parent) {
+            }
+        });
     }
 
     public void policyDeleteDialogReport(String message) {
@@ -362,19 +400,7 @@ public class OverViewPolicies extends AppCompatActivity {
         alertDialogBuilder
                 .setCancelable(false)
                 .setPositiveButton(getResources().getString(R.string.button_ok),
-                        (dialog, id) -> {
-                            finish();
-                            Intent intent = new Intent(OverViewPolicies.this, OverViewPolicies.class);
-                            intent.putExtra("RENEWAL", RadioRenewal);
-                            intent.putExtra("INSURANCE_NUMBER", InsuranceNumber);
-                            intent.putExtra("OTHER_NAMES", OtherNames);
-                            intent.putExtra("LAST_NAME", LastName);
-                            intent.putExtra("INSURANCE_PRODUCT", InsuranceProduct);
-                            intent.putExtra("UPLOADED_FROM", UploadedFrom);
-                            intent.putExtra("UPLOADED_TO", UploadedTo);
-                            intent.putExtra("REQUESTED_YES_NO", RadioRequested);
-                            startActivity(intent);
-                        });
+                        (dialog, id) -> refresh());
 
         // create alert dialog
         AlertDialog alertDialog = alertDialogBuilder.create();
@@ -482,88 +508,30 @@ public class OverViewPolicies extends AppCompatActivity {
         alertDialog.show();
     }
 
-    private int getControlNumber(final JSONObject order, final String SmsRequired) {
-        new Thread(() -> {
-            runOnUiThread(() -> pd = ProgressDialog.show(OverViewPolicies.this, "", getResources().getString(R.string.Get_Control_Number)));
-
-            HttpResponse response;
-            try {
-                response = toRestApi.postToRestApiToken(order, "GetControlNumber");
-                int code = response.getStatusLine().getStatusCode();
-
-                HttpEntity respEntity = response.getEntity();
-                String content;
-                if (respEntity != null) {
-                    final String[] error_occured = {null};
-                    final String[] error_message = {null};
-                    final String[] internal_Identifier = {null};
-                    final String[] control_number = {null};
-                    // EntityUtils to get the response content
-                    content = EntityUtils.toString(respEntity);
-
-                    try {
-                        JSONObject res = new JSONObject(content);
-
-                        error_occured[0] = res.getString("error_occured");
-                        if ("true".equals(error_occured[0])) {
-                            error_message[0] = res.getString("error_message");
-                            showSnackbar(error_message[0]);
-                        } else if (code == HttpURLConnection.HTTP_UNAUTHORIZED) {
-                            LoginDialogBox();
-                            showSnackbar(getResources().getString(R.string.has_no_rights));
-                        } else if (code == HttpURLConnection.HTTP_INTERNAL_ERROR) {
-                            showSnackbar(getResources().getString(R.string.SomethingWrongServer));
-                        } else if (code >= 400) { // for compatibility, but should not be needed
-                            showSnackbar(getResources().getString(R.string.SomethingWrongServer));
-                        } else {
-                            internal_Identifier[0] = res.getString("internal_identifier");
-                            control_number[0] = res.getString("control_number");
-                            int id = insertAfterRequest(amountConfirmed, control_number[0], internal_Identifier[0], PaymentType, SmsRequired);
-                            updateAfterRequest(id);
-                            runOnUiThread(() -> {
-                                num.clear();
-                                policyDeleteDialogReport(getResources().getString(R.string.requestSent));
-                            });
-                        }
-                        runOnUiThread(() -> pd.dismiss());
-                    } catch (JSONException e) {
-                        runOnUiThread(() -> pd.dismiss());
-                        showSnackbar(getResources().getString(R.string.SomethingWrongServer));
-                    }
-                } else {
-                    runOnUiThread(() -> pd.dismiss());
-                    showSnackbar(getResources().getString(R.string.NoInternet));
-                }
-            } catch (IOException e) {
-                runOnUiThread(() -> pd.dismiss());
-                showSnackbar(getResources().getString(R.string.NoInternet));
-            }
-        }).start();
-
-        return 0;
+    private void getControlNumber(final JSONObject order) {
+        pd = ProgressDialog.show(this, "", getResources().getString(R.string.Get_Control_Number));
+        ControlNumberService.requestControlNumber(this, order, paymentDetails);
     }
 
-    public void showSnackbar(String message)
-    {
+    private void handleRequestResult(Intent intent) {
+        if (intent.getAction().equals(ControlNumberService.ACTION_REQUEST_SUCCESS)) {
+            showSnackbar(getResources().getString(R.string.requestSent));
+            refresh();
+        } else if (intent.getAction().equals(ControlNumberService.ACTION_REQUEST_ERROR)) {
+            String errorMessage = intent.getStringExtra(ControlNumberService.FIELD_ERROR_MESSAGE);
+            showSnackbar(errorMessage);
+        }
+        pd.dismiss();
+    }
+
+    public void showSnackbar(String message) {
         View activity = findViewById(R.id.actv);
         Snackbar.make(activity, message, Snackbar.LENGTH_LONG)
                 .setAction("Action", null).show();
     }
 
-    private void updateAfterRequest(int ControlNumberId) {
-        JSONObject ob;
-        for (int j = 0; j < paymentDetails.length(); j++) {
-            try {
-                ob = paymentDetails.getJSONObject(j);
-                int Id = Integer.parseInt(ob.getString("Id"));
-                clientAndroidInterface.updateRecordedPolicy(Id, ControlNumberId);
-            } catch (JSONException e) {
-                e.printStackTrace();
-            }
-        }
-    }
-
-    private int insertAfterRequest(String amountCalculated, String control_number, String InternalIdentifier, String PaymentType, String SmsRequired) {
-        return clientAndroidInterface.insertRecordedPolicy(amountCalculated, amountConfirmed, control_number, InternalIdentifier, PaymentType, SmsRequired);
+    public void refresh() {
+        finish();
+        startActivity(getIntent());
     }
 }

--- a/app/src/main/java/org/openimis/imispolicies/OverViewPolicies.java
+++ b/app/src/main/java/org/openimis/imispolicies/OverViewPolicies.java
@@ -84,7 +84,6 @@ public class OverViewPolicies extends AppCompatActivity {
     String RadioRequested = "";
     static String PayType = "";
 
-
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -136,7 +135,6 @@ public class OverViewPolicies extends AppCompatActivity {
                             Snackbar.make(view1, getResources().getString(R.string.select_policy), Snackbar.LENGTH_LONG)
                                     .setAction("Action", null).show();
                         }
-
                     } catch (JSONException e) {
                         e.printStackTrace();
                     }
@@ -146,7 +144,6 @@ public class OverViewPolicies extends AppCompatActivity {
                 Snackbar.make(view1, getResources().getString(R.string.NoInternet), Snackbar.LENGTH_LONG)
                         .setAction("Action", null).show();
             }
-
         });
 
         Button deleteButton = findViewById(R.id.deleteButton);
@@ -186,7 +183,6 @@ public class OverViewPolicies extends AppCompatActivity {
                     num.clear();
                     policyDeleteDialogReport(getResources().getString(R.string.dataDeleted));
                 }
-
             } else {
                 runOnUiThread(() -> {
                     pd.dismiss();
@@ -194,12 +190,9 @@ public class OverViewPolicies extends AppCompatActivity {
                     Snackbar.make(view12, getResources().getString(R.string.no_data_delete), Snackbar.LENGTH_LONG)
                             .setAction("Action", null).show();
                 });
-
             }
-
         });
         clientAndroidInterface = new ClientAndroidInterface(this);
-
 
         InsuranceNumber = getIntent().getStringExtra("INSURANCE_NUMBER");
         OtherNames = getIntent().getStringExtra("OTHER_NAMES");
@@ -239,38 +232,6 @@ public class OverViewPolicies extends AppCompatActivity {
         }
     }
 
-/*    @RequiresApi(api = Build.VERSION_CODES.JELLY_BEAN)
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        MenuInflater inflater = getMenuInflater();
-        inflater.inflate(R.menu.options_menu, menu);
-
-        // Associate searchable configuration with the SearchView
-        SearchManager searchManager =
-                (SearchManager) getSystemService(Context.SEARCH_SERVICE);
-        SearchView searchView =
-                (SearchView) menu.findItem(R.id.search).getActionView();
-        searchView.setSearchableInfo(
-                searchManager.getSearchableInfo(getComponentName()));
-
-
-        searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
-
-            @Override
-            public boolean onQueryTextSubmit(String s) {
-                return false;
-            }
-
-            @Override
-            public boolean onQueryTextChange(String s) {
-                //overViewPoliciesAdapter.getFilter().filter(s);
-                return true;
-            }
-        });
-
-        return true;
-    }*/
-
     public boolean onOptionsItemSelected(MenuItem item) {
         onBackPressed();
         return true;
@@ -307,7 +268,6 @@ public class OverViewPolicies extends AppCompatActivity {
         final EditText phoneNumber = promptsView.findViewById(R.id.phonenumber);
         final Spinner payment_type = promptsView.findViewById(R.id.payment_type2);
         final CheckBox send_sms = promptsView.findViewById(R.id.send_sms);
-
 
         send_sms.setOnClickListener(view -> {
             if (((CompoundButton) view).isChecked()) {
@@ -354,8 +314,6 @@ public class OverViewPolicies extends AppCompatActivity {
                                 }
                             } catch (JSONException e) {
                                 e.printStackTrace();
-                            } catch (IOException e) {
-                                e.printStackTrace();
                             }
                         })
                 .setNegativeButton(getResources().getString(R.string.button_cancel),
@@ -373,7 +331,6 @@ public class OverViewPolicies extends AppCompatActivity {
         List<String> list = new ArrayList<>();
         list.add("Mobile Phone");
         list.add("Bank Transfer");
-
 
         TextView tv = findViewById(R.id.type1);
 
@@ -429,7 +386,6 @@ public class OverViewPolicies extends AppCompatActivity {
     public void LoginDialogBox() {
         if (!clientAndroidInterface.CheckInternetAvailable())
             return;
-
 
         Global global = (Global) OverViewPolicies.this.getApplicationContext();
 
@@ -511,17 +467,12 @@ public class OverViewPolicies extends AppCompatActivity {
                                             LoginDialogBox();
                                         });
                                     }
-
-
                                 }
                                 ).start();
-
-
                             } else {
                                 LoginDialogBox();
                                 Toast.makeText(OverViewPolicies.this, OverViewPolicies.this.getResources().getString(R.string.Enter_Credentials), Toast.LENGTH_LONG).show();
                             }
-
                         })
                 .setNegativeButton(R.string.Cancel,
                         (dialog, id) -> dialog.cancel());
@@ -531,7 +482,7 @@ public class OverViewPolicies extends AppCompatActivity {
         alertDialog.show();
     }
 
-    private int getControlNumber(final JSONObject order, final String SmsRequired) throws IOException {
+    private int getControlNumber(final JSONObject order, final String SmsRequired) {
         new Thread() {
             public void run() {
                 runOnUiThread(() -> pd = ProgressDialog.show(OverViewPolicies.this, "", getResources().getString(R.string.Get_Control_Number)));
@@ -539,6 +490,7 @@ public class OverViewPolicies extends AppCompatActivity {
                 HttpResponse response;
                 try {
                     response = toRestApi.postToRestApiToken(order, "GetControlNumber");
+                    int code = response.getStatusLine().getStatusCode();
 
                     HttpEntity respEntity = response.getEntity();
                     String content;
@@ -550,73 +502,42 @@ public class OverViewPolicies extends AppCompatActivity {
                         // EntityUtils to get the response content
                         content = EntityUtils.toString(respEntity);
 
-                        int cod = response.getStatusLine().getStatusCode();
-                        final int Finalcode = cod;
-                        if (cod >= 400) {
-                            JSONObject ob = null;
-                            try {
-                                ob = new JSONObject(content);
-                                error_occured[0] = ob.getString("error_occured");
-                                if (error_occured[0].equals("true")) {
-                                    error_message[0] = ob.getString("error_message");
-                                }
-                            } catch (Exception e) {
-                                e.printStackTrace();
-                            }
-                            runOnUiThread(() -> {
-                                pd.dismiss();
+                        try {
+                            JSONObject res = new JSONObject(content);
+
+                            error_occured[0] = res.getString("error_occured");
+                            if ("true".equals(error_occured[0])) {
+                                error_message[0] = res.getString("error_message");
+                                showSnackbar(error_message[0]);
+                            } else if (code == HttpURLConnection.HTTP_UNAUTHORIZED) {
                                 LoginDialogBox();
-                                if (tokenl.getTokenText().length() > 1) {
-                                    View view = findViewById(R.id.actv);
-                                    Snackbar.make(view, Finalcode + "-" + getResources().getString(R.string.has_no_rights), Snackbar.LENGTH_LONG)
-                                            .setAction("Action", null).show();
-                                }
-                            });
-
-                        } else {
-                            JSONObject ob;
-                            try {
-                                ob = new JSONObject(content);
-                                error_occured[0] = ob.getString("error_occured");
-                                if (error_occured[0].equals("true")) {
-                                    runOnUiThread(() -> pd.dismiss());
-                                    error_message[0] = ob.getString("error_message");
-
-                                    View view = findViewById(R.id.actv);
-                                    Snackbar.make(view, error_message[0], Snackbar.LENGTH_LONG)
-                                            .setAction("Action", null).show();
-                                } else {
-                                    internal_Identifier[0] = ob.getString("internal_identifier");
-                                    control_number[0] = ob.getString("control_number");
-                                    int id = insertAfterRequest(amountConfirmed, control_number[0], internal_Identifier[0], PaymentType, SmsRequired);
-                                    updateAfterRequest(id);
-                                    runOnUiThread(() -> {
-                                        pd.dismiss();
-
-                                        num.clear();
-                                        policyDeleteDialogReport(getResources().getString(R.string.requestSent));
-
-/*                                            View view = findViewById(R.id.actv);
-                                        Snackbar.make(view, getResources().getString(R.string.success), Snackbar.LENGTH_LONG)
-                                                .setAction("Action", null).show();*/
-                                    });
-                                }
-                            } catch (JSONException e) {
-                                runOnUiThread(() -> pd.dismiss());
-                                e.printStackTrace();
+                                showSnackbar(getResources().getString(R.string.has_no_rights));
+                            } else if (code == HttpURLConnection.HTTP_INTERNAL_ERROR) {
+                                showSnackbar(getResources().getString(R.string.SomethingWrongServer));
+                            } else if (code >= 400) { // for compatibility, but should not be needed
+                                showSnackbar(getResources().getString(R.string.SomethingWrongServer));
+                            } else {
+                                internal_Identifier[0] = res.getString("internal_identifier");
+                                control_number[0] = res.getString("control_number");
+                                int id = insertAfterRequest(amountConfirmed, control_number[0], internal_Identifier[0], PaymentType, SmsRequired);
+                                updateAfterRequest(id);
+                                runOnUiThread(() -> {
+                                    pd.dismiss();
+                                    num.clear();
+                                    policyDeleteDialogReport(getResources().getString(R.string.requestSent));
+                                });
                             }
+                        } catch (JSONException e) {
+                            runOnUiThread(() -> pd.dismiss());
+                            showSnackbar(getResources().getString(R.string.SomethingWrongServer));
                         }
                     } else {
                         runOnUiThread(() -> pd.dismiss());
-                        View view = findViewById(R.id.actv);
-                        Snackbar.make(view, getResources().getString(R.string.NoInternet), Snackbar.LENGTH_LONG)
-                                .setAction("Action", null).show();
+                        showSnackbar(getResources().getString(R.string.NoInternet));
                     }
-                } catch (Exception e) {
+                } catch (IOException e) {
                     runOnUiThread(() -> pd.dismiss());
-                    View view = findViewById(R.id.actv);
-                    Snackbar.make(view, getResources().getString(R.string.NoInternet), Snackbar.LENGTH_LONG)
-                            .setAction("Action", null).show();
+                    showSnackbar(getResources().getString(R.string.NoInternet));
                 }
             }
         }.start();
@@ -624,8 +545,15 @@ public class OverViewPolicies extends AppCompatActivity {
         return 0;
     }
 
+    public void showSnackbar(String message)
+    {
+        View activity = findViewById(R.id.actv);
+        Snackbar.make(activity, message, Snackbar.LENGTH_LONG)
+                .setAction("Action", null).show();
+    }
+
     private void updateAfterRequest(int ControlNumberId) {
-        JSONObject ob = null;
+        JSONObject ob;
         for (int j = 0; j < paymentDetails.length(); j++) {
             try {
                 ob = paymentDetails.getJSONObject(j);

--- a/app/src/main/java/org/openimis/imispolicies/OverViewPolicies.java
+++ b/app/src/main/java/org/openimis/imispolicies/OverViewPolicies.java
@@ -483,64 +483,62 @@ public class OverViewPolicies extends AppCompatActivity {
     }
 
     private int getControlNumber(final JSONObject order, final String SmsRequired) {
-        new Thread() {
-            public void run() {
-                runOnUiThread(() -> pd = ProgressDialog.show(OverViewPolicies.this, "", getResources().getString(R.string.Get_Control_Number)));
+        new Thread(() -> {
+            runOnUiThread(() -> pd = ProgressDialog.show(OverViewPolicies.this, "", getResources().getString(R.string.Get_Control_Number)));
 
-                HttpResponse response;
-                try {
-                    response = toRestApi.postToRestApiToken(order, "GetControlNumber");
-                    int code = response.getStatusLine().getStatusCode();
+            HttpResponse response;
+            try {
+                response = toRestApi.postToRestApiToken(order, "GetControlNumber");
+                int code = response.getStatusLine().getStatusCode();
 
-                    HttpEntity respEntity = response.getEntity();
-                    String content;
-                    if (respEntity != null) {
-                        final String[] error_occured = {null};
-                        final String[] error_message = {null};
-                        final String[] internal_Identifier = {null};
-                        final String[] control_number = {null};
-                        // EntityUtils to get the response content
-                        content = EntityUtils.toString(respEntity);
+                HttpEntity respEntity = response.getEntity();
+                String content;
+                if (respEntity != null) {
+                    final String[] error_occured = {null};
+                    final String[] error_message = {null};
+                    final String[] internal_Identifier = {null};
+                    final String[] control_number = {null};
+                    // EntityUtils to get the response content
+                    content = EntityUtils.toString(respEntity);
 
-                        try {
-                            JSONObject res = new JSONObject(content);
+                    try {
+                        JSONObject res = new JSONObject(content);
 
-                            error_occured[0] = res.getString("error_occured");
-                            if ("true".equals(error_occured[0])) {
-                                error_message[0] = res.getString("error_message");
-                                showSnackbar(error_message[0]);
-                            } else if (code == HttpURLConnection.HTTP_UNAUTHORIZED) {
-                                LoginDialogBox();
-                                showSnackbar(getResources().getString(R.string.has_no_rights));
-                            } else if (code == HttpURLConnection.HTTP_INTERNAL_ERROR) {
-                                showSnackbar(getResources().getString(R.string.SomethingWrongServer));
-                            } else if (code >= 400) { // for compatibility, but should not be needed
-                                showSnackbar(getResources().getString(R.string.SomethingWrongServer));
-                            } else {
-                                internal_Identifier[0] = res.getString("internal_identifier");
-                                control_number[0] = res.getString("control_number");
-                                int id = insertAfterRequest(amountConfirmed, control_number[0], internal_Identifier[0], PaymentType, SmsRequired);
-                                updateAfterRequest(id);
-                                runOnUiThread(() -> {
-                                    pd.dismiss();
-                                    num.clear();
-                                    policyDeleteDialogReport(getResources().getString(R.string.requestSent));
-                                });
-                            }
-                        } catch (JSONException e) {
-                            runOnUiThread(() -> pd.dismiss());
+                        error_occured[0] = res.getString("error_occured");
+                        if ("true".equals(error_occured[0])) {
+                            error_message[0] = res.getString("error_message");
+                            showSnackbar(error_message[0]);
+                        } else if (code == HttpURLConnection.HTTP_UNAUTHORIZED) {
+                            LoginDialogBox();
+                            showSnackbar(getResources().getString(R.string.has_no_rights));
+                        } else if (code == HttpURLConnection.HTTP_INTERNAL_ERROR) {
                             showSnackbar(getResources().getString(R.string.SomethingWrongServer));
+                        } else if (code >= 400) { // for compatibility, but should not be needed
+                            showSnackbar(getResources().getString(R.string.SomethingWrongServer));
+                        } else {
+                            internal_Identifier[0] = res.getString("internal_identifier");
+                            control_number[0] = res.getString("control_number");
+                            int id = insertAfterRequest(amountConfirmed, control_number[0], internal_Identifier[0], PaymentType, SmsRequired);
+                            updateAfterRequest(id);
+                            runOnUiThread(() -> {
+                                num.clear();
+                                policyDeleteDialogReport(getResources().getString(R.string.requestSent));
+                            });
                         }
-                    } else {
                         runOnUiThread(() -> pd.dismiss());
-                        showSnackbar(getResources().getString(R.string.NoInternet));
+                    } catch (JSONException e) {
+                        runOnUiThread(() -> pd.dismiss());
+                        showSnackbar(getResources().getString(R.string.SomethingWrongServer));
                     }
-                } catch (IOException e) {
+                } else {
                     runOnUiThread(() -> pd.dismiss());
                     showSnackbar(getResources().getString(R.string.NoInternet));
                 }
+            } catch (IOException e) {
+                runOnUiThread(() -> pd.dismiss());
+                showSnackbar(getResources().getString(R.string.NoInternet));
             }
-        }.start();
+        }).start();
 
         return 0;
     }


### PR DESCRIPTION
Changes:
- Deleted a condition which was making every offline policy invisible after a CN request (allowing re-requesting a CN for offline policy)
- Fixed getRequestedPolicies for overview of CN when no upload date is selected 
- Streamlined and fixed error processing of CN request related code
- Deleted some unused code

[https://openimis.atlassian.net/browse/OTC-325](https://openimis.atlassian.net/browse/OTC-325)