### PR TITLE
OTC-329: REST API POST Family should return HTTP 200 with db UUIDs in payload

### DIFF
--- a/app/src/main/assets/pages/Family.html
+++ b/app/src/main/assets/pages/Family.html
@@ -79,11 +79,11 @@ In case of dispute arising out or in relation to the use of the program, it is s
             <textarea id="txtPermanentAddress" datafield="FamilyAddress"></textarea>
         </li>
         <li id="ApprovalOfSMS">
-            <span strName="ApprovalOfSMS">Allow SMS Messages</span>
+            <span strName="approvalOfSMS">Allow SMS Messages</span>
             <select id="ddlApprovalOfSMS" datafield="ApprovalOfSMS"></select>
         </li>
         <li id="LanguageOfSMS">
-            <span strName="LanguageOfSMS">Language of SMS</span>
+            <span strName="languageOfSMS">Language of SMS</span>
             <select id="ddlLanguageOfSMS" datafield="LanguageOfSMS"></select>
         </li>
     </ul>


### PR DESCRIPTION
Changes:
- Modified family enrolment response parsing to fit the new format

Additional changes:
- Modified JS interface to log which resource strings cannot be found
- Fixed mismatch of resource string names for `ApprovalOfSMS` and `LanguageOfSMS` fields
- Fixed wrong string comparation

[https://openimis.atlassian.net/browse/OTC-329](https://openimis.atlassian.net/browse/OTC-329)