### PR TITLE
OTC-372: Add auto-assigning of pre-fetched control numbers to policy during enrolment

### DIFF
--- a/app/src/main/assets/pages/FamilyPolicies.html
+++ b/app/src/main/assets/pages/FamilyPolicies.html
@@ -38,7 +38,8 @@ In case of dispute arising out or in relation to the use of the program, it is s
 </head>
 <body>
 <div id="dialog-confirm" title="Confirm" style="display:none">
-    <p><span id="msgAlert" class="ui-icon-alert" style="float:left; margin:2px 2px 2px 0;"></span></p>
+    <p><span id="msgAlert" class="ui-icon-alert" style="float:left; margin:2px 2px 2px 0;"></span>
+    </p>
 </div>
 <div class="topPanel">
     <img src="../images/plus.png" alt="New" class="plusButton"/>
@@ -54,30 +55,34 @@ In case of dispute arising out or in relation to the use of the program, it is s
                 <h3 class="right" id="PolicyStatus"></h3>
                 <div class="dropdown">
                     <div id="menuDrop" class="dropdown-content">
-                       <ul class="ulMenu">
-                           <li id="liEdit">Edit</li>
-                           <li id="liDelete">Delete</li>
-                           <li id="liPay">Payment</li>
+                        <ul class="ulMenu">
+                            <li id="liEdit">Edit</li>
+                            <li id="liDelete">Delete</li>
+                            <li id="liPay">Payment</li>
 
-                       </ul>
+                        </ul>
                     </div>
                     <div class="clearFix"></div>
                 </div>
             </div>
 
 
-            <h4 id="ProductName"> </h4>
+            <h4 id="ProductName"></h4>
             <p>
-                <span  class="spLabel" >Effective Date : </span>
+                <span class="spLabel">Effective Date : </span>
                 <span id="EffectiveDate"></span>
-                <span  class="spLabel">Expire Date :</span>
+                <span class="spLabel">Expire Date :</span>
                 <span id="ExpireDate"></span>
             </p>
             <p>
                 <span class="spLabel">Start Date : </span>
-                <span   id="StartDate"></span>
-                <span  class="spLabel">Policy Value : </span>
+                <span id="StartDate"></span>
+                <span class="spLabel">Policy Value : </span>
                 <label id="PolicyValue"></label>
+            </p>
+            <p id="ControlNumberSection">
+                <span class="spLabel">Control Number : </span>
+                <span id="ControlNumber"></span>
             </p>
 
         </li>

--- a/app/src/main/assets/pages/FamilyPolicies.js
+++ b/app/src/main/assets/pages/FamilyPolicies.js
@@ -1,6 +1,10 @@
 $(document).ready(function () {
     document.title = Android.getString('FamilyAndPolicies');
 
+    if(!Android.IsBulkCNUsed()) {
+        $('#ControlNumberSection').hide();
+    }
+
     var FamilyId = queryString("f");
     var LocationId = parseInt(queryString("l"));
     var RegionId = parseInt(queryString("r"));
@@ -87,8 +91,8 @@ $(document).ready(function () {
 
 function LoadFamilyPolicies(FamilyId) {
     var Policies = Android.getFamilyPolicies(FamilyId);
-    var ctls = ["ProductCode", "ProductName", "StartDate", "ExpireDate", "PolicyValue", "PolicyStatus", "EffectiveDate", "hfPolicyId", "PolicyId", "hfIsOffline"];
-    var Columns = ["ProductCode", "ProductName", "StartDate", "ExpiryDate", "PolicyValue", "PolicyStatus", "EffectiveDate", "PolicyId", "PolicyId", "isOffline"];
+    var ctls = ["ProductCode", "ProductName", "StartDate", "ExpireDate", "PolicyValue", "PolicyStatus", "EffectiveDate", "hfPolicyId", "PolicyId", "hfIsOffline", "ControlNumber"];
+    var Columns = ["ProductCode", "ProductName", "StartDate", "ExpiryDate", "PolicyValue", "PolicyStatus", "EffectiveDate", "PolicyId", "PolicyId", "isOffline", "ControlNumber"];
     LoadList(Policies, '.ulList', ctls, Columns);
 }
 

--- a/app/src/main/assets/pages/Policy.html
+++ b/app/src/main/assets/pages/Policy.html
@@ -44,8 +44,8 @@ In case of dispute arising out or in relation to the use of the program, it is s
             <input datafield="PolicyValue" type="hidden" value="0" id="hfPolicyValue"/>
             <input datafield="PolicyStatusValue" type="hidden" value="1" id="hfPolicyStatus"/>
             <input datafield="isOffline" type="hidden" value="1" id="hfOffline"/>
-            <span  strName="EnrolmentDate">Enrolment date</span>
-            <input datafield="EnrollDate"  type="date" id="txtEnrolmentDate" required/>
+            <span strName="EnrolmentDate">Enrolment date</span>
+            <input datafield="EnrollDate" type="date" id="txtEnrolmentDate" required/>
         </li>
         <li id="Product">
             <span strName="Product">Product</span>
@@ -53,7 +53,7 @@ In case of dispute arising out or in relation to the use of the program, it is s
         </li>
         <li>
             <span strName="EffectiveDate">Effective date</span>
-            <input datafield="EffectiveDate" type="date" id="txtEffectiveDate" />
+            <input datafield="EffectiveDate" type="date" id="txtEffectiveDate"/>
         </li>
 
         <li>
@@ -69,24 +69,26 @@ In case of dispute arising out or in relation to the use of the program, it is s
             <span strName="Officer">Officer</span>
             <input type='hidden' datafield="OfficerId" type="date" id="ddlOfficer" required/>
         </li>
-
         <li>
             <span strName="PolicyStatus">Policy Status :</span>
             <span datafield="PolicyStatus" type="text" id="txtPolicyStatus"></span>
         </li>
+        <li id="ControlNumber">
+            <span strName="controlNumberLabel">Control Number :</span>
+            <span type="text" id="txtControlNumber"></span>
+            <input datafield="AssignedControlNumber" type="hidden" value=""
+                   id="AssignedControlNumber">
+        </li>
         <li>
             <span strName="PolicyValue">Policy Value :</span>
             <span datafield="PolicyValue" type="text" id="spPolicyValue">0</span>
-
         </li>
-
         <li>
             <span strName="Contribution">Contribution :</span>
             <span datafield="Contribution" type="text" id="spContribution">0</span>
             <span strName="Balance">Balance : </span>
             <span datafield="Balance" type="text" id="spBalance">0</span>
         </li>
-
     </ul>
 </div>
 <div class="footer">

--- a/app/src/main/assets/pages/Policy.html
+++ b/app/src/main/assets/pages/Policy.html
@@ -51,6 +51,10 @@ In case of dispute arising out or in relation to the use of the program, it is s
             <span strName="Product">Product</span>
             <select datafield="ProdId" id="ddlProduct" required></select>
         </li>
+        <li id="ControlNumber">
+            <span strName="controlNumberLabel">Control Number :</span>
+            <input datafield="AssignedControlNumber" type="text" id="AssignedControlNumber">
+        </li>
         <li>
             <span strName="EffectiveDate">Effective date</span>
             <input datafield="EffectiveDate" type="date" id="txtEffectiveDate"/>
@@ -59,7 +63,6 @@ In case of dispute arising out or in relation to the use of the program, it is s
         <li>
             <span strName="StartDate">Start date</span>
             <input datafield="StartDate" type="date" id="txtStartDate" required/>
-
         </li>
         <li>
             <span strName="ExpireDate">Expire date</span>
@@ -72,12 +75,6 @@ In case of dispute arising out or in relation to the use of the program, it is s
         <li>
             <span strName="PolicyStatus">Policy Status :</span>
             <span datafield="PolicyStatus" type="text" id="txtPolicyStatus"></span>
-        </li>
-        <li id="ControlNumber">
-            <span strName="controlNumberLabel">Control Number :</span>
-            <span type="text" id="txtControlNumber"></span>
-            <input datafield="AssignedControlNumber" type="hidden" value=""
-                   id="AssignedControlNumber">
         </li>
         <li>
             <span strName="PolicyValue">Policy Value :</span>

--- a/app/src/main/assets/pages/Policy.js
+++ b/app/src/main/assets/pages/Policy.js
@@ -88,7 +88,11 @@ $(document).ready(function () {
     $('#ddlProduct').change(function () {
         if(Android.IsBulkCNUsed()) {
             var productId = $('#ddlProduct').val();
-            if(productId == '0') return;
+            if(productId == '0') {
+                $('#txtControlNumber').text('');
+                $('#AssignedControlNumber').val('');
+                return;
+            }
             var controlNumber = Android.GetNextBulkCn(productId);
             if(typeof controlNumber === 'undefined') {
                 Android.ShowDialog(Android.getString('noBulkCNAvailable'));

--- a/app/src/main/assets/pages/Policy.js
+++ b/app/src/main/assets/pages/Policy.js
@@ -2,7 +2,7 @@ $(document).ready(function () {
     document.title = Android.getString('AddEditPolicy');
 
     if(!Android.IsBulkCNUsed()) {
-        $('#txtControlNumber').hide();
+        $('#ControlNumber').hide();
     }
 
     var LocationId = parseInt(queryString("l"));
@@ -44,8 +44,12 @@ $(document).ready(function () {
         $('#txtExpiryDate').val(ExpiryDate);
 
         if(Android.IsBulkCNUsed()) {
-            $('#txtControlNumber').text($Policy[0]["ControlNumber"]);
-            $('#AssignedControlNumber').val($Policy[0]["ControlNumber"]);
+            console.log(typeof $Policy[0]["ControlNumber"]);
+            if($Policy[0]["ControlNumber"]) {
+                $('#AssignedControlNumber').val($Policy[0]["ControlNumber"]).prop('readonly', true);
+            } else {
+                $('#AssignedControlNumber').val('').prop('readonly', false);
+            }
         }
 
         var HSCycle = false;
@@ -89,16 +93,15 @@ $(document).ready(function () {
         if(Android.IsBulkCNUsed()) {
             var productId = $('#ddlProduct').val();
             if(productId == '0') {
-                $('#txtControlNumber').text('');
-                $('#AssignedControlNumber').val('');
+                $('#AssignedControlNumber').val('').prop('readonly', false);
                 return;
             }
             var controlNumber = Android.GetNextBulkCn(productId);
             if(typeof controlNumber === 'undefined') {
                 Android.ShowDialog(Android.getString('noBulkCNAvailable'));
+                $('#AssignedControlNumber').val('').prop('readonly', false);
             } else {
-                $('#txtControlNumber').text(controlNumber);
-                $('#AssignedControlNumber').val(controlNumber);
+                $('#AssignedControlNumber').val(controlNumber).prop('readonly', true);
             }
         }
     });
@@ -108,8 +111,9 @@ $(document).ready(function () {
         var jsonPolicy = createJSONString();
 
         if (passed == true) {
-            if(Android.IsBulkCNUsed() && $('#AssignedControlNumber').val() === '') {
+            if(Android.IsBulkCNUsed() && !$('#AssignedControlNumber').val()) {
                 Android.ShowDialog(Android.getString('noBulkCNAssigned'));
+                $('#AssignedControlNumber').val('').prop('readonly', false);
                 return;
             }
 

--- a/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
+++ b/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
@@ -42,7 +42,6 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.icu.text.DecimalFormat;
 import android.net.Uri;
-import android.net.http.DelegatingSSLSession;
 import android.os.Build;
 import android.provider.MediaStore;
 import android.support.annotation.RequiresApi;
@@ -78,7 +77,6 @@ import java.util.Arrays;
 import java.util.Date;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
@@ -1941,6 +1939,7 @@ public class ClientAndroidInterface {
                 }
                 sqlHandler.updateData("tblPolicy", values, "PolicyId = ? AND (isOffline = ? OR isOffline = ?) ", new String[]{String.valueOf(PolicyId), String.valueOf(isOffline), String.valueOf(Online)});
                 if (IsBulkCNUsed()) {
+                    sqlHandler.clearCnAssignedToPolicy(PolicyId);
                     sqlHandler.assignCnToPolicy(PolicyId, controlNumber);
                 }
             }
@@ -2541,7 +2540,7 @@ public class ClientAndroidInterface {
         sqlHandler.deleteData(SQLHandler.tblRecordedPolicies, selector, arg);
         sqlHandler.deleteData(SQLHandler.tblInsureePolicy, selector, arg);
         sqlHandler.deleteData(SQLHandler.tblPolicy, selector, arg);
-        sqlHandler.clearCnAfterPolicyDeleted(PolicyId);
+        sqlHandler.clearCnAssignedToPolicy(PolicyId);
         return 1;
     }
 

--- a/app/src/main/java/org/openimis/imispolicies/ControlNumberService.java
+++ b/app/src/main/java/org/openimis/imispolicies/ControlNumberService.java
@@ -88,8 +88,11 @@ public class ControlNumberService extends IntentService {
     private void handleActionFetchBulkCN(String productCode) {
         String errorMessage;
         try {
+            JSONObject object = new JSONObject();
+            object.put("productCode", productCode);
+
             HttpEntity respEntity;
-            HttpResponse response = toRestApi.postToRestApiToken(null, String.format("GetControlNumbersForEO?productCode=%s", productCode));
+            HttpResponse response = toRestApi.postToRestApiToken(object, "GetControlNumbersForEO");
             int responseCode = response.getStatusLine().getStatusCode();
             respEntity = response.getEntity();
             String content = EntityUtils.toString(respEntity);

--- a/app/src/main/java/org/openimis/imispolicies/SQLHandler.java
+++ b/app/src/main/java/org/openimis/imispolicies/SQLHandler.java
@@ -963,7 +963,7 @@ public class SQLHandler extends SQLiteOpenHelper {
         return false;
     }
 
-    public boolean clearCnAfterPolicyDeleted(int policyId) {
+    public boolean clearCnAssignedToPolicy(int policyId) {
         openDatabase();
         ContentValues values = new ContentValues();
         values.put("PolicyId", (String) null);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -419,4 +419,7 @@
   <string name="FetchBulkCN">Fetch Bulk Control Numbers</string>
   <string name="Fetch">Fetch</string>
   <string name="LogInToFetchCn">Please log in first, to fetch control numbers.</string>
+  <string name="noBulkCNAvailable">No control numbers left for this product. Please fetch control numbers first.</string>
+  <string name="noBulkCNAssigned">No control number assigned to this policy. Please fetch control numbers first.</string>
+  <string name="controlNumberLabel">Control Number :</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -419,7 +419,7 @@
   <string name="FetchBulkCN">Fetch Bulk Control Numbers</string>
   <string name="Fetch">Fetch</string>
   <string name="LogInToFetchCn">Please log in first, to fetch control numbers.</string>
-  <string name="noBulkCNAvailable">No control numbers left for this product. Please fetch control numbers first.</string>
-  <string name="noBulkCNAssigned">No control number assigned to this policy. Please fetch control numbers first.</string>
+  <string name="noBulkCNAvailable">No control numbers left for this product. Please fetch control numbers or provide control number from other source.</string>
+  <string name="noBulkCNAssigned">No control number assigned to this policy. Please fetch control numbers or provide control number from other source.</string>
   <string name="controlNumberLabel">Control Number :</string>
 </resources>


### PR DESCRIPTION
Changes:
- Fetched bulk control numbers are automatically assigned to policies after product is selected, in case there is no control numbers left the message is displayed.
- Assigned control numbers are attached to enrolment payload.
- Assigned control numbers are displayed in `FamiliPolicies` and `Policy` pages.

Additional adjustments:
- Added process dialog when fetching control numbers.
- Fixed assigned and free control number counts.
- Products after thier active period are not visible in bulk CN fetch view.

[https://openimis.atlassian.net/browse/OTC-372](https://openimis.atlassian.net/browse/OTC-372)

preview:
![372-1](https://user-images.githubusercontent.com/32635788/132010116-c8dedce9-dc12-4147-a0b4-d6ec4fcf2981.png)
![372-2](https://user-images.githubusercontent.com/32635788/132010121-556e6395-2122-4883-980f-aef89384cb80.png)
