### PR TITLE
OTC-485: App crashes when saving an ulisted renewal

### DIFF
--- a/app/src/main/java/org/openimis/imispolicies/Renewal.java
+++ b/app/src/main/java/org/openimis/imispolicies/Renewal.java
@@ -176,15 +176,16 @@ public class Renewal extends AppCompatActivity {
                 pd = ProgressDialog.show(Renewal.this, "", getResources().getString(R.string.Uploading));
                 final String[] renewal = {null};
 
-                new Thread(() -> {
-                    if (getIntent().getStringExtra("CHFID").equals(getResources().getString(R.string.UnlistedRenewalPolicies))) {
-                        etProductCode.setText(GetSelectedProduct());
-                    }
+                if (getIntent().getStringExtra("CHFID").equals(getResources().getString(R.string.UnlistedRenewalPolicies))) {
+                    etProductCode.setText(GetSelectedProduct());
+                }
 
-                    if (!isValidate()) {
-                        pd.dismiss();
-                        return;
-                    }
+                if (!isValidate()) {
+                    pd.dismiss();
+                    return;
+                }
+
+                new Thread(() -> {
                     renewal[0] = WriteJSON();
                     WriteXML();
                     result = 3;


### PR DESCRIPTION
Changes:
- Fixed a bug regarding updating a view on separate thread

[https://openimis.atlassian.net/browse/OTC-485](https://openimis.atlassian.net/browse/OTC-485)