### PR TITLE
OP-187: IMIS web and policies app: Renewal extracts dont work

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,8 +2,8 @@ import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 apply plugin: 'com.android.application'
+apply plugin: "org.ajoberstar.grgit"
 apply from: "$project.rootDir/script-git-version.gradle"
-apply plugin: 'com.android.application'
 
 // Load keystore
 def keystorePropertiesFile = file("keystore.properties")
@@ -149,8 +149,6 @@ android {
             resValue "string", "app_name_policies", "Policies CHF SIT"
         }
         niger {
-            print("Building niger flavour" + "API_BASE_URL" + '"' + (System.getenv("API_BASE_URL") ?: 'http://192.168.0.100/') + '"')
-            print("App name: " + System.getenv("CLI_APP_NAME") ?: "Polices Niger")
             applicationId "org.openimis.imispolicies.niger"
             buildConfigField "String", "API_BASE_URL", '"' + (System.getenv("API_BASE_URL") ?: 'http://192.168.0.100/') + '"'
             buildConfigField "String", "APP_DIR", '"' + (System.getenv("CLI_APP_DIR") ?: 'IMIS-POL') + '"'
@@ -216,8 +214,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 }
 
@@ -236,6 +234,6 @@ dependencies {
     androidTestImplementation('com.android.support.test.espresso:espresso-core:2.2.2', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    testImplementation 'junit:junit:4.12'
+    testImplementation 'junit:junit:4.13.1'
     //compile 'com.android.support:support-annotations:27.1.1'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,12 +15,8 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
-    <uses-permission
-        android:name="android.permission.READ_CALL_LOG"
-        tools:node="remove" />
-    <uses-permission
-        android:name="android.permission.READ_CONTACTS"
-        tools:node="remove" />
+    <uses-permission android:name="android.permission.READ_CALL_LOG"/>
+    <uses-permission android:name="android.permission.READ_CONTACTS"/>
 
     <uses-feature
         android:name="android.hardware.camera"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,8 +15,6 @@
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="android.permission.READ_CALL_LOG"/>
-    <uses-permission android:name="android.permission.READ_CONTACTS"/>
 
     <uses-feature
         android:name="android.hardware.camera"

--- a/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
+++ b/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
@@ -2602,9 +2602,24 @@ public class ClientAndroidInterface {
     }
 
 
-    public String InsertRenewals(String Result) {
+    public String InsertRenewalsFromApi(String Result) {
         String TableName = "tblRenewals";
         String[] Columns = {"renewalId", "policyId", "officerId", "officerCode", "chfid", "lastName", "otherNames", "productCode", "productName", "villageName", "renewalPromptDate", "phone", "renewalUUID"};
+        String Where = "isDone = ?";
+        String[] WhereArg = {"N"};
+        sqlHandler.deleteData(TableName, Where, WhereArg);
+        try {
+            sqlHandler.insertData(TableName, Columns, Result, "");
+        } catch (JSONException e) {
+            e.printStackTrace();
+            return String.valueOf(0);
+        }
+        return String.valueOf(1);
+    }
+
+    public String InsertRenewalsFromExtract(String Result) {
+        String TableName = "tblRenewals";
+        String[] Columns = {"RenewalId", "PolicyId", "OfficerId", "OfficerCode", "CHFID", "LastName", "OtherNames", "ProductCode", "ProductName", "VillageName", "RenewalPromptDate", "Phone", "RenewalUUID"};
         String Where = "isDone = ?";
         String[] WhereArg = {"N"};
         sqlHandler.deleteData(TableName, Where, WhereArg);
@@ -3942,7 +3957,6 @@ public class ClientAndroidInterface {
     public boolean unZipFeedbacksRenewals(String FileName) {
         String targetPath = global.getSubdirectory("Database") + File.separator + FileName;
         String unzippedFolderPath = global.getSubdirectory("Database");
-        //String unzippedFolderPath = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOCUMENTS) + "/IMIS/Enrolment/Enrolment_"+global.getOfficerCode()+"_"+d+".xml";
 
         String password = getRarPwd();
         try {

--- a/app/src/main/java/org/openimis/imispolicies/RenewList.java
+++ b/app/src/main/java/org/openimis/imispolicies/RenewList.java
@@ -36,6 +36,7 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.text.Editable;
 import android.text.TextWatcher;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -49,16 +50,17 @@ import android.widget.SimpleAdapter;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpResponse;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileOutputStream;
 import java.io.IOException;
-import java.io.InputStreamReader;
+import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -66,12 +68,13 @@ import java.util.Calendar;
 import java.util.HashMap;
 
 public class RenewList extends AppCompatActivity {
+    private static final String LOG_TAG = "RENEWAL";
     private static final int REQUEST_OPEN_DOCUMENT_CODE = 1;
     private Global global;
     private String aBuffer = "";
     private ListView lv;
     private SwipeRefreshLayout swipe;
-    private ArrayList<HashMap<String, String>> RenewalList = new ArrayList<>();
+    private ArrayList<HashMap<String, String>> renewalList = new ArrayList<>();
     private String OfficerCode;
     private ClientAndroidInterface ca;
     private ListAdapter adapter;
@@ -104,27 +107,19 @@ public class RenewList extends AppCompatActivity {
         swipe.setEnabled(false);
         swipe.setOnRefreshListener(() -> {
             swipe.setRefreshing(true);
-            (new Handler()).postDelayed(() -> {
-                Token token = null;
-
-                try {
-                    token = global.getJWTToken();
-                } catch (Exception e) {
-                }
-
+            new Handler().postDelayed(() -> {
                 if (global.isNetworkAvailable()) {
-                    if (token != null) {
-                        RefreshRenewals();
+                    if (global.isLoggedIn()) {
+                        refreshRenewals();
                     } else {
-                        LoginDialogBox("Renewals");
+                        loginDialogBox(this::refreshRenewals);
                     }
                 } else {
-                    openDialogForFeedbackRenewal();
+                    requestImportRenewal();
                 }
 
-                // FetchPayers();
                 swipe.setRefreshing(false);
-            }, 3000);
+            }, 1000);
         });
 
         etRenewalSearch.addTextChangedListener(new TextWatcher() {
@@ -141,7 +136,6 @@ public class RenewList extends AppCompatActivity {
             public void afterTextChanged(Editable s) {
             }
         });
-
 
         lv.setOnScrollListener(new AbsListView.OnScrollListener() {
             @Override
@@ -168,9 +162,7 @@ public class RenewList extends AppCompatActivity {
             intent.putExtra("PolicyValue", oItem.get("PolicyValue"));
             intent.putExtra("RenewalUUID", oItem.get("RenewalUUID"));
             startActivity(intent);
-
         });
-
     }
 
     @Override
@@ -179,105 +171,95 @@ public class RenewList extends AppCompatActivity {
         fillRenewals();
     }
 
-    public void ConfirmDialogFeedbackRenewal(String filename) {
-        AlertDialog.Builder alertDialog2 = new AlertDialog.Builder(
-                RenewList.this);
-
-// Setting Dialog Title
-        alertDialog2.setTitle("Load file:");
-        alertDialog2.setMessage(filename);
-
-// Setting Icon to Dialog
-        // alertDialog2.setIcon(R.drawable.delete);
-
-// Setting Positive "Yes" Btn
-        alertDialog2.setPositiveButton("OK",
-                (dialog, which) -> {
-                    if (ca.InsertRenewals(aBuffer).equals("1")) {
-                        fillRenewals();
-                    }
-                }).setNegativeButton("Quit",
-                (dialog, id) -> {
-                    dialog.cancel();
-                    finish();
-                });
-
-// Showing Alert Dialog
-        alertDialog2.show();
+    public void confirmImportRenewal(String filename, Uri uri) {
+        new AlertDialog.Builder(this)
+                .setTitle(R.string.LoadFile)
+                .setMessage(filename)
+                .setPositiveButton(R.string.Yes,
+                        (dialog, which) -> new Thread(() -> {
+                            if (copyRenewalFile(filename, uri)) {
+                                ca.unZipFeedbacksRenewals(filename);
+                                String txtFilename = Util.FileUtil.replaceFilenameExtension(filename, ".txt");
+                                loadRenewalFile(txtFilename);
+                                ca.InsertRenewalsFromExtract(aBuffer);
+                                runOnUiThread(this::fillRenewals);
+                            }
+                        }).start())
+                .setNegativeButton(R.string.No,
+                        (dialog, id) -> dialog.cancel())
+                .show();
     }
 
-    public String getMasterDataText(String filename) {
-        ca.unZipFeedbacksRenewals(filename);
-        String fname = filename.substring(0, filename.indexOf("."));
+    private void loadRenewalFile(String filename) {
+        File file = new File(global.getSubdirectory("Database"), filename);
         try {
-            String dir = global.getSubdirectory("Database");
-            File myFile = new File(dir, fname);//"/"+dir+"/MasterData.txt"
-//            BufferedReader myReader = new BufferedReader(
-//                    new InputStreamReader(
-//                            new FileInputStream(myFile), "UTF32"));
-            FileInputStream fIn = new FileInputStream(myFile);
-            BufferedReader myReader = new BufferedReader(new InputStreamReader(fIn));
-            aBuffer = myReader.readLine();
-
-            myReader.close();
-/*            Scanner in = new Scanner(new FileReader("/"+dir+"/MasterData.txt"));
-            StringBuilder sb = new StringBuilder();
-            while(in.hasNext()) {
-                sb.append(in.next());
+            if (file.exists()) {
+                InputStream inputStream = new FileInputStream(file);
+                aBuffer = Util.FileUtil.readInputStreamAsUTF8String(inputStream);
+            } else {
+                Log.e(LOG_TAG, "Unpacked renewal file does not exists");
             }
-            in.close();
-            aBuffer = sb.toString();*/
         } catch (IOException e) {
-            e.printStackTrace();
+            Log.e(LOG_TAG, "Error while creating input stream for renewal file", e);
         }
-        return aBuffer;
     }
 
-    public void openDialogForFeedbackRenewal() {
-        AlertDialog.Builder alertDialog2 = new AlertDialog.Builder(
-                RenewList.this);
+    private boolean copyRenewalFile(String filename, Uri uri) {
+        try {
+            boolean success;
+            InputStream is = getContentResolver().openInputStream(uri);
+            File outputFile = new File(global.getSubdirectory("Database"), filename);
 
-// Setting Dialog Title
-        alertDialog2.setTitle("NO INTERNET CONNECTION");
-        alertDialog2.setMessage("Do you want to import .txt file from your IMIS folder?");
+            if (outputFile.exists()) {
+                success = outputFile.delete();
+                if (!success) {
+                    throw new IOException("Deleting existing renewal file failed");
+                }
+            }
 
-// Setting Icon to Dialog
-        // alertDialog2.setIcon(R.drawable.delete);
+            success = outputFile.createNewFile();
+            if (!success) {
+                throw new IOException("Creating new renewal file failed");
+            }
 
-// Setting Positive "Yes" Btn
-        alertDialog2.setPositiveButton("Yes",
-                (dialog, which) -> {
+            IOUtils.copy(is, new FileOutputStream(outputFile));
+            return true;
+        } catch (Exception e) {
+            Log.e(LOG_TAG, "Copying renewal file failed", e);
+        }
+        return false;
+    }
 
-                    Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
-                    intent.addCategory(Intent.CATEGORY_OPENABLE);
-                    intent.setType("*/*");
-                    try {
-                        startActivityForResult(intent, REQUEST_OPEN_DOCUMENT_CODE);
-                    } catch (ActivityNotFoundException e) {
-                        Toast.makeText(getApplicationContext(), "There are no file explorer clients installed.", Toast.LENGTH_SHORT).show();
-                    }
-                    // Write your code here to execute after dialog
-                }).setNegativeButton("No",
-                (dialog, id) -> {
-                    dialog.cancel();
-                    finish();
-                });
-
-// Showing Alert Dialog
-        alertDialog2.show();
+    public void requestImportRenewal() {
+        new AlertDialog.Builder(this)
+                .setTitle(R.string.NoInternetTitle)
+                .setMessage(R.string.ImportRenewalFile)
+                .setPositiveButton(R.string.Yes,
+                        (dialog, which) -> {
+                            Intent intent = new Intent(Intent.ACTION_GET_CONTENT);
+                            intent.addCategory(Intent.CATEGORY_OPENABLE);
+                            intent.setType("*/*");
+                            try {
+                                startActivityForResult(intent, REQUEST_OPEN_DOCUMENT_CODE);
+                            } catch (ActivityNotFoundException e) {
+                                Toast.makeText(getApplicationContext(), getResources().getString(R.string.NoFileExporerInstalled), Toast.LENGTH_SHORT).show();
+                            }
+                        })
+                .setNegativeButton(R.string.No,
+                        (dialog, id) -> dialog.cancel())
+                .show();
     }
 
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
-        if (requestCode == REQUEST_OPEN_DOCUMENT_CODE && resultCode == RESULT_OK) {
+        if (requestCode == REQUEST_OPEN_DOCUMENT_CODE && resultCode == RESULT_OK && data != null) {
             Uri uri = data.getData();
-            String path = uri.getPath();
-            File f = new File(path);
+            String filename = Util.UriUtil.getDisplayName(this, uri);
+            String expectedFilename = String.format("renewal_%s.rar", global.getOfficerCode().toLowerCase());
 
-            if (f.getName().toLowerCase().equals("renewal_" + global.getOfficerCode().toLowerCase() + ".rar")) {
-                getMasterDataText((f.getName()));
-                ConfirmDialogFeedbackRenewal((f.getName()));
+            if (filename != null && filename.toLowerCase().equals(expectedFilename)) {
+                confirmImportRenewal(filename, uri);
             } else {
                 Toast.makeText(this, getResources().getString(R.string.FileDoesntBelongHere), Toast.LENGTH_LONG).show();
             }
@@ -286,73 +268,53 @@ public class RenewList extends AppCompatActivity {
     }
 
     private void fillRenewals() {
-        RenewalList.clear();
+        renewalList.clear();
         SimpleDateFormat format = AppInformation.DateTimeInfo.getDefaultDateFormatter();
         Calendar cal = Calendar.getInstance();
         String d = format.format(cal.getTime());
 
         ClientAndroidInterface ca = new ClientAndroidInterface(this);
         String result = ca.OfflineRenewals(OfficerCode);
-        JSONArray jsonArray;
         JSONObject object;
 
         try {
-            RenewalList.clear();
-            jsonArray = new JSONArray(result);
-            HashMap<String, String> Renewal;
-            Renewal = new HashMap<>();
-            Renewal.put("RenewalId", "0");
-            Renewal.put("CHFID", UnlistedRenPolicy);
-            Renewal.put("FullName", getResources().getString(R.string.RenewYourPolicy));
-            Renewal.put("Product", getResources().getString(R.string.Product));
-            Renewal.put("VillageName", "");
-            Renewal.put("PolicyValue", "");
-            Renewal.put("PolicyId", "");
-            Renewal.put("ProductCode", "");
-            Renewal.put("LocationId", String.valueOf(ca.getLocationId(OfficerCode)));
-            Renewal.put("RenewalPromptDate", d);
-            Renewal.put("RenewalUUID", "");
-            RenewalList.add(Renewal);
-            if (jsonArray.length() == 0) {
-                //RenewalList.clear();
-                //Toast.makeText(this, getResources().getString(R.string.NoRenewalFound), Toast.LENGTH_LONG).show();
-            } else {
-                RenewalList.clear();
-                Renewal = new HashMap<>();
-                Renewal.put("RenewalId", "0");
-                Renewal.put("CHFID", UnlistedRenPolicy);
-                Renewal.put("FullName", getResources().getString(R.string.RenewYourPolicy));
-                Renewal.put("Product", getResources().getString(R.string.Product));
-                Renewal.put("VillageName", "");
-                Renewal.put("PolicyValue", "");
-                Renewal.put("PolicyId", "");
-                Renewal.put("ProductCode", "");
-                Renewal.put("LocationId", String.valueOf(ca.getLocationId(OfficerCode)));
-                Renewal.put("RenewalPromptDate", d);
-                Renewal.put("RenewalUUID", "");
-                RenewalList.add(Renewal);
-                for (int i = 0; i < jsonArray.length(); i++) {
+            HashMap<String,String> renewal;
+            JSONArray jsonArray = new JSONArray(result);
 
-                    object = jsonArray.getJSONObject(i);
+            renewalList.clear();
+            renewal = new HashMap<>();
+            renewal.put("RenewalId", "0");
+            renewal.put("CHFID", UnlistedRenPolicy);
+            renewal.put("FullName", getResources().getString(R.string.RenewYourPolicy));
+            renewal.put("Product", getResources().getString(R.string.Product));
+            renewal.put("VillageName", "");
+            renewal.put("PolicyValue", "");
+            renewal.put("PolicyId", "");
+            renewal.put("ProductCode", "");
+            renewal.put("LocationId", String.valueOf(ca.getLocationId(OfficerCode)));
+            renewal.put("RenewalPromptDate", d);
+            renewal.put("RenewalUUID", "");
+            renewalList.add(renewal);
 
-                    Renewal = new HashMap<>();
-                    Renewal.put("RenewalId", object.getString("RenewalId"));
-                    Renewal.put("CHFID", object.getString("CHFID"));
-                    Renewal.put("FullName", object.getString("LastName") + " " + object.getString("OtherNames"));
-                    Renewal.put("Product", object.getString("ProductCode") + " : " + object.getString("ProductName"));
-                    Renewal.put("VillageName", object.getString("VillageName"));
-                    Renewal.put("RenewalPromptDate", object.getString("RenewalPromptDate"));
-                    Renewal.put("PolicyId", object.getString("PolicyId"));
-                    Renewal.put("ProductCode", object.getString("ProductCode"));
-                    Renewal.put("LocationId", object.getString("LocationId"));
-                    Renewal.put("PolicyValue", object.getString("PolicyValue"));
-                    Renewal.put("RenewalUUID", object.getString("RenewalUUID"));
-                    RenewalList.add(Renewal);
-                }
+            for (int i = 0; i < jsonArray.length(); i++) {
+
+                object = jsonArray.getJSONObject(i);
+                renewal = new HashMap<>();
+                renewal.put("RenewalId", object.getString("RenewalId"));
+                renewal.put("CHFID", object.getString("CHFID"));
+                renewal.put("FullName", object.getString("LastName") + " " + object.getString("OtherNames"));
+                renewal.put("Product", object.getString("ProductCode") + " : " + object.getString("ProductName"));
+                renewal.put("VillageName", object.getString("VillageName"));
+                renewal.put("RenewalPromptDate", object.getString("RenewalPromptDate"));
+                renewal.put("PolicyId", object.getString("PolicyId"));
+                renewal.put("ProductCode", object.getString("ProductCode"));
+                renewal.put("LocationId", object.getString("LocationId"));
+                renewal.put("PolicyValue", object.getString("PolicyValue"));
+                renewal.put("RenewalUUID", object.getString("RenewalUUID"));
+                renewalList.add(renewal);
             }
 
-
-            adapter = new SimpleAdapter(this, RenewalList, R.layout.renewallist,
+            adapter = new SimpleAdapter(this, renewalList, R.layout.renewallist,
                     new String[]{"CHFID", "FullName", "Product", "VillageName", "RenewalPromptDate"},
                     new int[]{R.id.tvCHFID, R.id.tvFullName, R.id.tvProduct, R.id.tvVillage, R.id.tvTime});
 
@@ -366,7 +328,7 @@ public class RenewList extends AppCompatActivity {
 
     }
 
-    private void RefreshRenewals() {
+    private void refreshRenewals() {
         if (global.isNetworkAvailable()) {
             if (global.isLoggedIn()) {
                 new Thread(() -> {
@@ -382,7 +344,7 @@ public class RenewList extends AppCompatActivity {
                     }
 
                     if (responseCode == HttpURLConnection.HTTP_OK && result != null) {
-                        ca.InsertRenewals(result);
+                        ca.InsertRenewalsFromApi(result);
                         runOnUiThread(this::fillRenewals);
                     } else if (responseCode == HttpURLConnection.HTTP_UNAUTHORIZED) {
                         Toast.makeText(this, getResources().getString(R.string.LogInToDownloadRenewals), Toast.LENGTH_LONG).show();
@@ -395,8 +357,7 @@ public class RenewList extends AppCompatActivity {
                 Toast.makeText(this, getResources().getString(R.string.LogInToDownloadRenewals), Toast.LENGTH_LONG).show();
             }
         } else {
-            openDialogForFeedbackRenewal();
-            //Toast.makeText(this, getResources().getString(R.string.NoInternet), Toast.LENGTH_LONG).show();
+            requestImportRenewal();
         }
     }
 
@@ -409,36 +370,18 @@ public class RenewList extends AppCompatActivity {
 
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case android.R.id.home:
-                finish();
-                return true;
-            case R.id.mnuStatistics:
-                if (!ca.CheckInternetAvailable()) {
-                    return false;
-                }
-                Intent stats = new Intent(this, Statistics.class);
-                stats.putExtra("Title", "Renewal Statistics");
-                stats.putExtra("Caller", "R");
-                startActivity(stats);
-                return true;
-            default:
-                return super.onOptionsItemSelected(item);
-        }
+        onBackPressed();
+        return true;
     }
 
-    public void LoginDialogBox(final String page) {
-        if (!ca.CheckInternetAvailable())
+    public void loginDialogBox(Runnable onLoggedIn) {
+        if (!global.isNetworkAvailable())
             return;
 
-        Global global = (Global) RenewList.this.getApplicationContext();
-        // get prompts.xml view
         LayoutInflater li = LayoutInflater.from(this);
         View promptsView = li.inflate(R.layout.login_dialog, null);
 
         AlertDialog.Builder alertDialogBuilder = new AlertDialog.Builder(this);
-
-        // set prompts.xml to alertdialog builder
         alertDialogBuilder.setView(promptsView);
 
         final TextView username = promptsView.findViewById(R.id.UserName);
@@ -446,44 +389,28 @@ public class RenewList extends AppCompatActivity {
 
         username.setText(global.getOfficerCode());
 
-        // set dialog message
         alertDialogBuilder
                 .setCancelable(false)
                 .setPositiveButton(R.string.Ok,
                         (dialog, id) -> {
                             if (!username.getText().toString().equals("") && !password.getText().toString().equals("")) {
-
                                 new Thread(() -> {
-
                                     isUserLogged = ca.LoginToken(username.getText().toString(), password.getText().toString());
-
                                     runOnUiThread(() -> {
                                         if (isUserLogged) {
-                                            if (page.equals("Renewals")) {
-                                                finish();
-                                                Intent intent = new Intent(RenewList.this, RenewList.class);
-                                                startActivity(intent);
-                                                Toast.makeText(RenewList.this, RenewList.this.getResources().getString(R.string.Login_Successful), Toast.LENGTH_LONG).show();
-                                            }
-
+                                            onLoggedIn.run();
                                         } else {
                                             Toast.makeText(RenewList.this, RenewList.this.getResources().getString(R.string.LoginFail), Toast.LENGTH_LONG).show();
-                                            LoginDialogBox(page);
-                                            //ca.ShowDialog(RenewList.this.getResources().getString(R.string.LoginFail));
+                                            loginDialogBox(onLoggedIn);
                                         }
                                     });
                                 }).start();
                             } else {
                                 Toast.makeText(RenewList.this, RenewList.this.getResources().getString(R.string.Enter_Credentials), Toast.LENGTH_LONG).show();
-                                LoginDialogBox(page);
+                                loginDialogBox(onLoggedIn);
                             }
                         })
-                .setNegativeButton(R.string.Cancel, (dialog, id) -> dialog.cancel());
-
-        // create alert dialog
-        AlertDialog alertDialog = alertDialogBuilder.create();
-
-        // show it
-        alertDialog.show();
+                .setNegativeButton(R.string.Cancel, (dialog, id) -> dialog.cancel())
+                .show();
     }
 }

--- a/app/src/main/java/org/openimis/imispolicies/SQLHandler.java
+++ b/app/src/main/java/org/openimis/imispolicies/SQLHandler.java
@@ -734,14 +734,13 @@ public class SQLHandler extends SQLiteOpenHelper {
         String dbPath = ClientAndroidInterface.filePath;
         mDatabase = SQLiteDatabase.openDatabase(dbPath, null, SQLiteDatabase.OPEN_READWRITE);
         try {
-            JSONArray array = null;
+            JSONArray array;
             JSONObject object;
 
             array = new JSONArray(data);
 
             if (array.length() == 0)
                 return;
-
 
             if (!mDatabase.isOpen()) {
                 openDatabase();

--- a/app/src/main/java/org/openimis/imispolicies/Util.java
+++ b/app/src/main/java/org/openimis/imispolicies/Util.java
@@ -3,12 +3,22 @@ package org.openimis.imispolicies;
 import android.app.AlertDialog;
 import android.app.ProgressDialog;
 import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.OpenableColumns;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
+import android.util.Log;
 import android.widget.Toast;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 public class Util {
     public static class StringUtil {
@@ -94,6 +104,68 @@ public class Util {
                     .setCancelable(false)
                     .setPositiveButton(R.string.Ok, (dialogInterface, i) -> {
                     }).show();
+        }
+    }
+
+    public static class UriUtil {
+        private static final String LOG_TAG = "UriUtil";
+
+        public static String getDisplayName(Context context, Uri uri) {
+            try (Cursor c = context.getContentResolver().query(uri, new String[]{OpenableColumns.DISPLAY_NAME}, null, null, null)) {
+                c.moveToFirst();
+                c.moveToFirst();
+                return c.getString(c.getColumnIndex(OpenableColumns.DISPLAY_NAME));
+            } catch (Exception e) {
+                Log.e(LOG_TAG, "Reading file name from URI failed", e);
+            }
+            return null;
+        }
+    }
+
+    public static class FileUtil {
+        private static final String LOG_TAG = "FileUtil";
+
+        /**
+         * Only use this method if you can be sure the content of the input stream,
+         * can be read, is a UTF-8 text and will fit in memory (as String).
+         * There is a reason this is not a part of the standard libraries.
+         *
+         * @param is input stream to be read
+         * @return content of the input stream or null if IO exception occurs
+         */
+        public static String readInputStreamAsUTF8String(InputStream is) {
+            BufferedReader streamReader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+            StringBuilder stringBuilder = new StringBuilder();
+
+            try {
+                String inputStr;
+                while ((inputStr = streamReader.readLine()) != null)
+                    stringBuilder.append(inputStr);
+                return stringBuilder.toString();
+            } catch (IOException e) {
+                Log.e(LOG_TAG, "Error while reading input stream", e);
+            }
+
+            return null;
+        }
+
+        /**
+         * Replaces the extension of the file
+         *
+         * @param filename filename ending with extension
+         * @param targetExtension target extension, including a dot (to protect from replacing
+         *                        a substring inside filename that match current extension)
+         * @return filename with replaced extension, or null if the filename does not end with
+         * extension
+         */
+        public static String replaceFilenameExtension(String filename, String targetExtension) {
+            try {
+                String currentExtension = filename.substring(filename.lastIndexOf('.'));
+                return filename.replace(currentExtension, targetExtension);
+            } catch (IndexOutOfBoundsException e) {
+                Log.e(LOG_TAG, "Filename does not have an extension at the end", e);
+            }
+            return null;
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -436,4 +436,9 @@
     <string name="UnexpectedException">Unexpected exception</string>
     <string name="InvalidRenewalFile">Invalid renewal file</string>
     <string name="ConfirmControlNumber">Control number \"%1$s\" is not present in phone memory. Please confirm that this control number is correct.</string>
+    <string name="ImportRenewalFile">Do you want to select renewal file to import?</string>
+    <string name="RarPassword">RAR Password</string>
+    <string name="SaveRarPassword">Save RAR Password</string>
+    <string name="BackToDefaultPassword">Set the default RAR password</string>
+    <string name="BackToDefault">Default RAR Password</string>
 </resources>

--- a/build.gradle
+++ b/build.gradle
@@ -1,25 +1,22 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     repositories {
-        jcenter()
         google()
+        mavenCentral()
+        maven {
+            name = 'ajoberstar-backup'
+            url = 'https://ajoberstar.org/bintray-backup/'
+        }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.2'
-
-        // NOTE: Do not place your application dependencies here; they belong
-        // in the individual module build.gradle files
+        classpath 'com.android.tools.build:gradle:7.0.3'
+        classpath "org.ajoberstar.grgit:grgit-gradle:4.1.0"
     }
 }
 
 allprojects {
     repositories {
-        jcenter()
         google()
-        maven {
-            url "https://maven.google.com"
-        }
+        mavenCentral()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip

--- a/script-git-version.gradle
+++ b/script-git-version.gradle
@@ -1,23 +1,18 @@
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
+        maven {
+            name = 'ajoberstar-backup'
+            url = 'https://ajoberstar.org/bintray-backup/'
+        }
     }
     dependencies {
-        classpath 'org.ajoberstar.grgit:grgit-gradle:4.1.0'
+        classpath "org.ajoberstar.grgit:grgit-gradle:4.1.0"
     }
 }
 
 import org.ajoberstar.grgit.Grgit
-
-/**
- * git.describe()
- *
- * Find the most recent tag that is reachable from HEAD. If the tag points to the commit,
- * then only the tag is shown. Otherwise, it suffixes the tag name with the number of additional
- * commits on top of the tagged object and the abbreviated object name of the most recent commit.
- *
- * More info: https://git-scm.com/docs/git-describe
- */
 
 ext {
     git = Grgit.open(currentDir: projectDir)


### PR DESCRIPTION
Changes:
- Updated renewal extreact import feature to work with Android 10/11 filesystem security
- Chaged hard-coded strings used in renewal extreact import to string resources
- Fixed missing string resources in `Settings` page

Maintenance:
- removad all references to `Jcenter` repository (read-only from March 31st, 2021, replaced with `Maven`)
- Bumped Java version to 11 (LTS) (Packaged with newest stable version of Android Studio, also required by one dependency, does not break compability with older versions of Android)
- Bumped Gradle varsion to 7.0.2