### PR TITLE
OTC-529 Remove logging framework from release version of the app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ out/
 # Gradle files
 .gradle/
 build/
-release/
 
 # Local configuration file (sdk path, etc)
 local.properties

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -53,15 +53,16 @@ android {
             if ( keystorePropertiesFile.exists() ) {
                 signingConfig signingConfigs.releaseConfig
             }
-            buildConfigField "boolean", "LOG", "false"
+            buildConfigField "boolean", "LOGGING_ENABLED", "false"
 
             // Refer to https://developer.android.com/reference/android/util/Log for the log level values
+            // Irrelevant if LOGGING_ENABLED = false
             buildConfigField "int", "CONSOLE_LOG_LEVEL", '8' //Assert
             buildConfigField "int", "FILE_LOG_LEVEL", '8' //Assert
         }
         debug {
             debuggable = true
-            buildConfigField "boolean", "LOG", "true"
+            buildConfigField "boolean", "LOGGING_ENABLED", "true"
 
             // Refer to https://developer.android.com/reference/android/util/Log for the log level values
             buildConfigField "int", "CONSOLE_LOG_LEVEL", '2' //Verbose

--- a/app/src/main/assets/pages/Settings.html
+++ b/app/src/main/assets/pages/Settings.html
@@ -1,60 +1,64 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
+
 <head>
     <title>Settings</title>
-    <link href="../CSS/Style.CSS" rel="stylesheet" type="text/css"/>
+    <link href="../CSS/Style.CSS" rel="stylesheet" type="text/css" />
     <script src="../JS/jquery-3.2.1.min.js"></script>
     <script src="../JS/exact.js"></script>
-    <meta name="viewport" content="initial-scale=1.0, user-scalable=no" charset="utf-8"/>
+    <meta name="viewport" content="initial-scale=1.0, user-scalable=no" charset="utf-8" />
 
     <script type="text/javascript" src="Settings.js"></script>
 
 </head>
+
 <body>
-<div>
-    <ul class="ulEntry">
-        <li>
-            <span strName="RarPassword">RAR Password</span>
-            <input type="password" id="rarPassword" required/>
-        </li>
-    </ul>
+    <div>
+        <ul class="ulEntry">
+            <li>
+                <span strName="RarPassword">RAR Password</span>
+                <input type="password" id="rarPassword" required />
+            </li>
+        </ul>
 
-    <div class="footer">
-        <input type="submit" id="btnSaveRarPassword" strName="SaveRarPassword" value="Save">
+        <div class="footer">
+            <input type="submit" id="btnSaveRarPassword" strName="SaveRarPassword" value="Save">
+        </div>
+
+        <br />
+
+        <ul class="ulEntry">
+            <li>
+                <span strName="BackToDefaultPassword">Set the default RAR password</span>
+            </li>
+        </ul>
+        <div class="footer">
+            <input type="submit" id="btnBackToDefault" strName="BackToDefault" value="Save">
+        </div>
+
+        <br />
+        <div id="logSection">
+            <ul class="ulEntry">
+                <li>
+                    <span strName="ExportLogs">Export logs</span>
+                </li>
+            </ul>
+            <div class="footer">
+                <input type="submit" id="btnExportLogs" strName="ExportLogsButton" value="Save">
+            </div>
+
+            <br />
+
+            <ul class="ulEntry">
+                <li>
+                    <span strName="ClearLogs">Clear logs</span>
+                </li>
+            </ul>
+            <div class="footer">
+                <input type="submit" id="btnClearLogs" strName="ClearLogsButton" value="Save">
+            </div>
+        </div>
     </div>
-
-    <br />
-
-    <ul class="ulEntry">
-        <li>
-            <span strName="BackToDefaultPassword">Set the default RAR password</span>
-        </li>
-    </ul>
-    <div class="footer">
-        <input type="submit" id="btnBackToDefault" strName="BackToDefault" value="Save">
-    </div>
-
-    <br />
-
-    <ul class="ulEntry">
-        <li>
-            <span strName="ExportLogs">Export logs</span>
-        </li>
-    </ul>
-    <div class="footer">
-        <input type="submit" id="btnExportLogs" strName="ExportLogsButton" value="Save">
-    </div>
-
-    <br />
-
-    <ul class="ulEntry">
-        <li>
-            <span strName="ClearLogs">Clear logs</span>
-        </li>
-    </ul>
-    <div class="footer">
-        <input type="submit" id="btnClearLogs" strName="ClearLogsButton" value="Save">
-    </div>
-</div>
 </body>
+
 </html>

--- a/app/src/main/assets/pages/Settings.js
+++ b/app/src/main/assets/pages/Settings.js
@@ -26,11 +26,15 @@ $(document).ready(function () {
         }
     });
 
-    $('#btnExportLogs').click(function () {
-        Android.exportLogs()
-    });
+    if (Android.isLoggingEnabled()) {
+        $('#btnExportLogs').click(function () {
+            Android.exportLogs()
+        });
 
-    $('#btnClearLogs').click(function () {
-        Android.clearLogs()
-    });
+        $('#btnClearLogs').click(function () {
+            Android.clearLogs()
+        });
+    } else {
+        $('#logSection').hide();
+    }
 });

--- a/app/src/main/java/org/openimis/imispolicies/Global.java
+++ b/app/src/main/java/org/openimis/imispolicies/Global.java
@@ -40,6 +40,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Environment;
 import android.util.DisplayMetrics;
+
 import org.openimis.imispolicies.tools.Log;
 
 import org.json.JSONArray;
@@ -384,13 +385,13 @@ public class Global extends Application {
         }
     }
 
-    public void sendFile(Context context, Uri uri, String mimeType) {
+    public void sendFile(Uri uri, String mimeType) {
         Intent shareExportIntent = new Intent(Intent.ACTION_SEND);
         shareExportIntent.setFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
         shareExportIntent.putExtra(Intent.EXTRA_STREAM, uri);
         shareExportIntent.setType(mimeType);
         Intent chooserIntent = Intent.createChooser(shareExportIntent, null);
-        grantUriPermissions(context, uri, chooserIntent, Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        context.startActivity(chooserIntent);
+        grantUriPermissions(this, uri, chooserIntent, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+        startActivity(chooserIntent);
     }
 }

--- a/app/src/release/java/org/openimis/imispolicies/tools/Log.java
+++ b/app/src/release/java/org/openimis/imispolicies/tools/Log.java
@@ -1,0 +1,48 @@
+package org.openimis.imispolicies.tools;
+
+import org.openimis.imispolicies.BuildConfig;
+
+/**
+ * This class is a wrapper for the default android Log class, adding additional functionality while
+ * keeping the android.util.Log api
+ * Release version should not allow any logging
+ */
+public class Log {
+    public static final boolean isLoggingEnabled = BuildConfig.LOGGING_ENABLED;
+
+    public static void v(String tag, String msg) {
+    }
+
+    public static void v(String tag, String msg, Throwable thr) {
+    }
+
+    public static void d(String tag, String msg) {
+    }
+
+    public static void d(String tag, String msg, Throwable thr) {
+    }
+
+    public static void i(String tag, String msg) {
+    }
+
+    public static void i(String tag, String msg, Throwable thr) {
+    }
+
+    public static void w(String tag, String msg) {
+    }
+
+    public static void w(String tag, String msg, Throwable thr) {
+    }
+
+    public static void e(String tag, String msg) {
+    }
+
+    public static void e(String tag, String msg, Throwable thr) {
+    }
+
+    public static void zipLogFiles() {
+    }
+
+    public static void deleteLogFiles() {
+    }
+}


### PR DESCRIPTION
[https://openimis.atlassian.net/browse/OTC-529](https://openimis.atlassian.net/browse/OTC-529)

Changes:
- Moved logging framework into a debug build
- Added an empty version of the logging framework to release build
- Disabled the logging related buttons in settings on the release build
- Removed `release/` part from `gitignore`. This section is not a part of gradle project structure and it prevents for `release` build specific code and resources from being commited.