### PR TITLE
OTC-370: Null values now stored as a null type and not a string.

### DIFF
--- a/app/src/main/java/org/openimis/imispolicies/SQLHandler.java
+++ b/app/src/main/java/org/openimis/imispolicies/SQLHandler.java
@@ -755,7 +755,12 @@ public class SQLHandler extends SQLiteOpenHelper {
                     object = array.getJSONObject(i);
                     ContentValues cv = new ContentValues();
                     for (String c : Columns) {
-                        cv.put(c, object.getString(c));
+                        if (object.getString(c).equalsIgnoreCase("NULL")) {
+                            cv.putNull(c);
+                        }
+                        else{
+                            cv.put(c, object.getString(c));
+                        }
                     }
                     mDatabase.insert(TableName, null, cv);
 


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OTC-370

Changes:
- NULL data stored in the local database now stored as a NULL type not as a string "NULL"