### PR TITLE
OTC-536: Added check for empty value of phone number of an insuree

### DIFF
--- a/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
+++ b/app/src/main/java/org/openimis/imispolicies/ClientAndroidInterface.java
@@ -110,6 +110,7 @@ import java.util.regex.Pattern;
 
 import org.openimis.imispolicies.tools.Util;
 import org.openimis.imispolicies.tools.Util.AndroidUtil;
+import org.openimis.imispolicies.tools.Util.JsonUtil;
 import org.xmlpull.v1.XmlSerializer;
 
 import javax.crypto.Cipher;
@@ -5761,7 +5762,7 @@ public class ClientAndroidInterface {
                     "familyAddress", "ethnicity", "confirmationNo", "confirmationType"};
             sqlHandler.insertData("tblFamilies", Columns, jsonArray.toString(), "");
 
-            if (object.has("familySMS")) {
+            if (!Util.JsonUtil.isStringEmpty(object, "familySMS", true)) {
                 JSONObject smsData = object.getJSONObject("familySMS");
                 try {
                     addOrUpdateFamilySms(object.getInt("familyId"),


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OTC-536

Changes:
- Using method created in utils, app now checks whether phone number of a given insuree exists, before trying to save it in the db
