### PR TITLE
OTC-582: Input checks for new renewals now are displayed properly.

### DIFF
--- a/app/src/main/java/org/openimis/imispolicies/Renewal.java
+++ b/app/src/main/java/org/openimis/imispolicies/Renewal.java
@@ -186,6 +186,7 @@ public class Renewal extends AppCompatActivity {
                 }
 
                 if (!isValidate()) {
+                    pd = ProgressDialog.show(this, "", "");
                     pd.dismiss();
                     return;
                 }

--- a/app/src/main/java/org/openimis/imispolicies/Renewal.java
+++ b/app/src/main/java/org/openimis/imispolicies/Renewal.java
@@ -186,8 +186,6 @@ public class Renewal extends AppCompatActivity {
                 }
 
                 if (!isValidate()) {
-                    pd = ProgressDialog.show(this, "", "");
-                    pd.dismiss();
                     return;
                 }
 


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OTC-582

Changes:
- Unfilled position in renewal form now doesn't crash the app
- Warnings about missing data now display properly