### PR TITLE
OTC-581: Custom message is now displayed when no policy is active.

### DIFF
--- a/app/src/main/java/org/openimis/imispolicies/Enquire.java
+++ b/app/src/main/java/org/openimis/imispolicies/Enquire.java
@@ -325,12 +325,16 @@ public class Enquire extends AppCompatActivity {
 
                         }
 
-
-                        Policy.put("Heading", jsonObject.getString("productCode"));
-                        Policy.put("Heading1", jsonObject.getString("expiryDate") + "  " + jsonObject.getString("status"));
-                        Policy.put("SubItem1", jsonObject.getString("productName"));
-                        Policy.put("SubItem2", Ded);
-                        Policy.put("SubItem3", Ceiling);
+                        if (jsonObject.getString("expiryDate").equals("null")){
+                            Policy.put("Heading", getResources().getString(R.string.EnquireNoPolicies));
+                        }
+                        else{
+                            Policy.put("Heading", jsonObject.getString("productCode"));
+                            Policy.put("Heading1", jsonObject.getString("expiryDate") + "  " + jsonObject.getString("status"));
+                            Policy.put("SubItem1", jsonObject.getString("productName"));
+                            Policy.put("SubItem2", Ded);
+                            Policy.put("SubItem3", Ceiling);
+                        }
 
                         String TotalAdmissionsLeft = buildEnquireValue(jsonObject, "totalAdmissionsLeft", R.string.totalAdmissionsLeft);
                         String TotalVisitsLeft = buildEnquireValue(jsonObject, "totalVisitsLeft", R.string.totalVisitsLeft);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -459,4 +459,5 @@
     <string name="WithoutPolicy">without a policy</string>
     <string name="WithoutPremium">without a premium</string>
     <string name="HttpResponse">HTTP response: %1$d — %2$s</string>
+    <string name="EnquireNoPolicies">No policies registered.</string>
 </resources>


### PR DESCRIPTION
https://openimis.atlassian.net/browse/OTC-581

Changes:
- Changed message when using enquire function on insuree with no active policy.
- Instead of null the message says that no active policy is registered.
- Function checks for expiryDate and compares it to null, since it was the variable that originally generated "null" message.