### PR TITLE
Compile resource fix

### DIFF
--- a/app/src/localeMv/res/values/strings.xml
+++ b/app/src/localeMv/res/values/strings.xml
@@ -477,5 +477,4 @@
     <string name="CurrentResourceLanguage">Current resource language: %1$s</string>
     <string name="SystemLanguageNotSupported">Current system language is not supported. The app will use the default language.</string>
     <string name="SupportedLanguages">Supported languages:\n%1$s</string>
-    <string name="DataDownloadedFailed">Data download failed</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -477,4 +477,5 @@
     <string name="CurrentResourceLanguage">Current resource language: %1$s</string>
     <string name="SystemLanguageNotSupported">Current system language is not supported. The app will use the default language.</string>
     <string name="SupportedLanguages">Supported languages:\n%1$s</string>
+    <string name="DataDownloadedFailed">Data download failed</string>
 </resources>


### PR DESCRIPTION
Changes:
- Moved `DataDownloadedFailed` string key to the appropriate file (default string resources)